### PR TITLE
readme: simple instructions for session inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ directory after it is completed.
 - `protocol` contains consensus level features
 - `ecopod` contains application level features
 - `security` contains failure mode analysis documents
+
+## Scheduling Inclusion in a Design Review Session
+
+The agendas for design doc review sessions are being tracked on 
+Github [here](https://github.com/ethereum-optimism/design-docs/issues/15).
+Please comment on the Github issue that corresponds to the design
+review session that you would like to have your design doc included in.


### PR DESCRIPTION
**Description**

Create some simple instructions for enable devs to
schedule design review sessions. The schedule lives
on Github and the process involves commenting on the
github issue that corresponds to the design review
session that you would like to have your design
doc reviewed in.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

