### PR TITLE
feat: adding limited space mirror factory

### DIFF
--- a/protocol/superc20/mirror-factory-limited.md
+++ b/protocol/superc20/mirror-factory-limited.md
@@ -36,7 +36,7 @@ This gives us:
 - Simple factory code.
 
 > [!NOTE]
-> An important note is that L1 must also be able to deploy `Mirror` contracts. We don’t have control over the factory address on L1. Therefore, to ensure the same `Mirror` address for a given token is maintained across chains, the factory pre-deploy will not follow the `0x42.....N` standard, but it will have to match the factory’s deployment address on L1 in all chains.
+> 💡 An important note is that L1 must also be able to deploy `Mirror` contracts. We don’t have control over the factory address on L1. Therefore, to ensure the same `Mirror` address for a given token is maintained across chains, the factory pre-deploy will not follow the `0x42.....N` standard, but it will have to match the factory’s deployment address on L1 in all chains.
 
 The salt doesn't need to be more than the `OptimismMintableERC20Token` address. The `name` and `symbol` can be queried from the implementation code. The `Mirror` will take in the token it extends as an argument and the factory address as its admin to allow for upgrades.
 

--- a/protocol/superc20/mirror-factory-limited.md
+++ b/protocol/superc20/mirror-factory-limited.md
@@ -1,0 +1,103 @@
+# Summary
+
+*The work present below is part of the [Interoperability project](https://github.com/ethereum-optimism/optimism/issues/10899).*
+
+A factory to spin up `ISuperchainERC20` Mirrors of `OptimismMintableERC20Tokens` is required. This document aims to provide a design for such a factory.
+
+# Problem Statement + Context
+
+A vast amount of `OptimismMintableERC20Tokens` currently exists in the ecosystem. These tokens do not have interoperable properties. Therefore, they require a migration to become interoperable. The migration will be performed through Mirrors, as specified by [Mirror Standard](https://github.com/ethereum-optimism/design-docs/pull/36). These Mirrors must be easily deployed through a predefined factory to ensure all Mirrors share the same functionality and address across chains and also to verify their legitimacy.
+
+The factory must facilitate the creation of a single legitimate Mirror per `OptimistismMintableERC20Token` to avoid liquidity fragmentation and unnecessary complexity.
+
+# Alternatives Considered
+
+- Creation Methods:
+    - Using `CREATE`. Discarded due to nonce dependability.
+    - Using `CREATE3`. Discarded due to unnecessary complexity.
+- Upgradability
+    - Deploying the `Mirror` without a `Proxy` and simply updating the `mirrors`' mapping to point to a new address when the Mirror is upgraded was discarded. Maintaining the `Mirrors'` addresses across chains is crucial *at all times,* and this approach could cause synchronization issues where one `Mirror` was updated in a given chain but not in another, resulting in different mirror addresses for the same token.
+
+# Proposed Solution
+
+Limiting the scope to `OptimismMintableERC20Tokens` allows using `CREATE2` instead of `CREATE3`, which is more expensive and complex. This is because the variables CREATE2 uses to define the address are salt, the child's init code, and the sender's address, which provide us with all the needed properties.
+
+The `Mirror` needs to be upgradable. Therefore, a Proxy contract will take the `_token` as an argument and `delegatecall` to the `Mirror` implementation.
+
+> [!NOTE]
+>💡 From now on, when we say `Mirror`, we’re referring to the proxy, not the implementation.
+
+Using the `OptimismMintableERC20Token` address as the salt allows linking the `Mirror` to this specific token. The sender's address will be the factory. The factory will be a pre-deploy which must be maintained across chains. This means the same `Mirror` address for the given salt/token will be kept.
+
+This gives us:
+
+- Address predictability. For each token, we know the corresponding Mirror.
+- Consistent addresses across chains.
+- Simple factory code.
+
+> [!NOTE]
+> An important note is that L1 must also be able to deploy `Mirror` contracts. We don’t have control over the factory address on L1. Therefore, to ensure the same `Mirror` address for a given token is maintained across chains, the factory pre-deploy will not follow the `0x42.....N` standard, but it will have to match the factory’s deployment address on L1 in all chains.
+
+The salt doesn't need to be more than the `OptimismMintableERC20Token` address. The `name` and `symbol` can be queried from the implementation code. The `Mirror` will take in the token it extends as an argument and the factory address as its admin to allow for upgrades.
+
+The factory should be upgradable or have setters to allow the creation of `Mirrors` with new implementations. This means the factory should also allow old, already-deployed `Mirrors` to be updated to new ones. A function `upgradeMirror` is introduced to accomplish this.
+
+We can track versioning through numbers or the addresses of the implementations used.
+
+The mirror implementation contract should be deployed beforehand. The Proxy must properly match storage slots with the mirror implementation storage.
+
+This design allows the `StandardBridge` to call `mirrors(_token)` when a `Mirror` contract performs a `transfer` and validates the mirror belongs to the `_token`. As an illustrative example:
+
+```solidity
+function mirrorMint(_token, amount) external {
+	address _mirror = MIRROR_FACTORY.mirrors(_token);
+	if (_mirror != msg.sender) revert();
+	///...mint logic
+}
+
+```
+
+Example code:
+
+```solidity
+contract MirrorFactory {
+	string public constant MIRROR_VERSION = "1.0.0";
+	Mirror public constant MIRROR_IMPL = <PLACEHOLDER_ADDRESS>;
+
+	mapping(address token => address _mirror) public mirrors;
+	// this could be a mapping to IMPLs
+	mapping(address token => string version) public mirrorVersions;
+
+	function deployMirror(address _token) external returns (address) {
+		// Check if its `OptimismMintableERC20Token`?
+		if (mirrors[_token] != address(0)) revert();
+		Proxy _mirror = address(new Proxy{salt: keccak256(abi.encode(_token))}(address(this), _token));
+		_updateMirror(_mirror, _token);
+	}
+
+	function upgradeMirror(address _mirror) external {
+		if (mirror[token] == address(0)) revert();
+		if (mirrorVersions[mirror] == MIRROR_VERSION) revert();
+		_updateMirror(_mirror, _token);
+		//..........
+	}
+
+	function _updateMirror(address _mirror, address _token) internal {
+		mirrors[_token] = _mirror;
+		mirrorVersions[_mirror] = MIRROR_VERSION;
+		_mirror.setImplementation(MIRROR_IMPL);
+	}
+
+	// Note: we could fuse both functions into deployMirror.
+	// Separating them here for clarity.
+}
+
+```
+
+# Risks & Uncertainties
+
+This only accounts for `OptimismMintableERC20Tokens`. The design space is limited for simplicity. Legacy tokens with different bytecodes are not considered. New interoperable tokens using the `Superc20` standard, which will have a different bytecode as well, are not taken into account for this factory.
+
+If the design space were to be extended `Create3` and extra predeploys would be needed.
+
+Current `OptimismMintableERC20Tokens` deployed by OP and Ethereum mainnet factories have different versions and, therefore, different bytecodes. This should not be a problem as the Mirror does not care about these changes.

--- a/protocol/superc20/mirror-factory-limited.md
+++ b/protocol/superc20/mirror-factory-limited.md
@@ -2,55 +2,37 @@
 
 *The work present below is part of the [Interoperability project](https://github.com/ethereum-optimism/optimism/issues/10899).*
 
-A factory to spin up `ISuperchainERC20` Mirrors of `OptimismMintableERC20Tokens` is required. This document aims to provide a design for such a factory.
+A factory to spin up `ISuperchainERC20` Mirrors of `OptimismMintableERC20Tokens` is required. This document aims to provide a design for such a factory. The Mirrors need to be proxied to address any future addition of features. The factory will deploy these proxies. Therefore, from now on, when we say `Mirror` we refer to the Proxy and not the implementation.
 
 # Problem Statement + Context
 
-A vast amount of `OptimismMintableERC20Tokens` currently exists in the ecosystem. These tokens do not have interoperable properties. Therefore, they require a migration to become interoperable. The migration will be performed through Mirrors, as specified by [Mirror Standard](https://github.com/ethereum-optimism/design-docs/pull/36). These Mirrors must be easily deployed through a predefined factory to ensure all Mirrors share the same functionality and address across chains and also to verify their legitimacy.
+A vast amount of `OptimismMintableERC20Tokens` currently exist in the ecosystem. These tokens do not have interoperable properties. Therefore, they require a migration to become interoperable. The migration will be performed through Mirrors, as specified by [Mirror Standard](https://github.com/ethereum-optimism/design-docs/pull/36). These Mirrors must be easily deployed through a predefined factory to ensure all Mirrors share the same functionality and address across chains and also to verify their legitimacy.
 
 The factory must facilitate the creation of a single legitimate Mirror per `OptimistismMintableERC20Token` to avoid liquidity fragmentation and unnecessary complexity.
 
 # Alternatives Considered
-
-- Creation Methods:
-    - Using `CREATE`. Discarded due to nonce dependability.
-    - Using `CREATE3`. Discarded due to unnecessary complexity.
-- Upgradability
-    - Deploying the `Mirror` without a `Proxy` and simply updating the `mirrors`' mapping to point to a new address when the Mirror is upgraded was discarded. Maintaining the `Mirrors'` addresses across chains is crucial *at all times,* and this approach could cause synchronization issues where one `Mirror` was updated in a given chain but not in another, resulting in different mirror addresses for the same token.
+- Using `CREATE`. Discarded due to nonce dependability.
+- Using `CREATE3`. Viable, yet not preferred due to increased complexity.
 
 # Proposed Solution
 
-Limiting the scope to `OptimismMintableERC20Tokens` allows using `CREATE2` instead of `CREATE3`, which is more expensive and complex. This is because the variables CREATE2 uses to define the address are salt, the child's init code, and the sender's address, which provide us with all the needed properties.
+Limiting the scope to `OptimismMintableERC20Tokens` allows using `CREATE2` instead of `CREATE3`, which is more expensive and complex. This is because the variables CREATE2 uses to define the address of the deployed contract provides all the properties we need to maintain the same address accross chains and easily verify whether a mirror was deployed by the official factory or not:
 
-The `Mirror` needs to be upgradable. Therefore, a Proxy contract will take the `_token` as an argument and `delegatecall` to the `Mirror` implementation.
+- `Salt`: If we use the `token` address, we can link the `Mirror` to this `token`. This will allow other contracts to know whether a caller is a legitimate `Mirror` or not.
+- `Sender Address`: In this case, it will be the Factory address itself, or the address of the factory's proxy. This works well, as it the factory can be deployed at the same address accross different chains. For chains in the superchain, it will be a predeploy. This predeploy, however, won't have a pretty address. Instead, it has to be deployed at the address where the L1 Factory is deployed so the address is maintained for all chains.
+- `Init Code`: The same proxy's init code must be used accross chains.
 
-> [!NOTE]
->💡 From now on, when we say `Mirror`, we’re referring to the proxy, not the implementation.
+The salt doesn't need to be more than the `OptimismMintableERC20Token` address. The `name` and `symbol`, and `decimals` can be fetched with the `token` address alone in the implementation. The factory will be the `Mirror`'s admin, and the proxy will have to either call `setStorage` immediately with the `token` at the time of deployment, or add a `TOKEN_SLOT` and update it on the constructor.
 
-Using the `OptimismMintableERC20Token` address as the salt allows linking the `Mirror` to this specific token. The sender's address will be the factory. The factory will be a pre-deploy which must be maintained across chains. This means the same `Mirror` address for the given salt/token will be kept.
-
-This gives us:
-
-- Address predictability. For each token, we know the corresponding Mirror.
-- Consistent addresses across chains.
-- Simple factory code.
-
-> [!NOTE]
-> 💡 An important note is that L1 must also be able to deploy `Mirror` contracts. We don’t have control over the factory address on L1. Therefore, to ensure the same `Mirror` address for a given token is maintained across chains, the factory pre-deploy will not follow the `0x42.....N` standard, but it will have to match the factory’s deployment address on L1 in all chains.
-
-The salt doesn't need to be more than the `OptimismMintableERC20Token` address. The `name` and `symbol` can be queried from the implementation code. The `Mirror` will take in the token it extends as an argument and the factory address as its admin to allow for upgrades.
-
-The factory should be upgradable or have setters to allow the creation of `Mirrors` with new implementations. This means the factory should also allow old, already-deployed `Mirrors` to be updated to new ones. A function `upgradeMirror` is introduced to accomplish this.
+The factory should be upgradable or have setters to allow the modification of the implementations for the current `Mirrors`. The deployment and update of already-deployed `Mirrors` to new implementations should be open to anyone.
 
 We can track versioning through numbers or the addresses of the implementations used.
 
-The mirror implementation contract should be deployed beforehand. The Proxy must properly match storage slots with the mirror implementation storage.
-
-This design allows the `StandardBridge` to call `mirrors(_token)` when a `Mirror` contract performs a `transfer` and validates the mirror belongs to the `_token`. As an illustrative example:
+This design allows the `StandardBridge` or any contract that needs to check the legitimacy of a `Mirror` to call `MIRROR_FACTORY.getMirrorAddress()` and validate whether the calling user is a mirror that corresponds to a given `token`. As an illustrative example of a potential function of the `StandardBridge`:
 
 ```solidity
 function mirrorMint(address _token, uint256 _amount) external {
-	address _mirror = MIRROR_FACTORY.mirrors(_token);
+	address _mirror = MIRROR_FACTORY.getMirrorAddress(_token);
 	if (_mirror != msg.sender) revert();
 	///...mint logic
 }
@@ -64,40 +46,45 @@ contract MirrorFactory {
 	string public constant MIRROR_VERSION = "1.0.0";
 	Mirror public constant MIRROR_IMPL = <PLACEHOLDER_ADDRESS>;
 
-	mapping(address token => address _mirror) public mirrors;
-	// this could be a mapping to IMPLs
-	mapping(address token => string version) public mirrorVersions;
-
 	function deployMirror(address _token) external returns (address) {
-		// Check if its `OptimismMintableERC20Token`?
-		if (mirrors[_token] != address(0)) revert();
-		Proxy _mirror = address(new Proxy{salt: keccak256(abi.encode(_token))}(address(this), _token));
-		_updateMirror(_mirror, _token);
-	}
+		require(_isOptimismMintableERC20(_token), "not OptimismMintableERC20Token");
 
-	function upgradeMirror(address _mirror) external {
-		if (mirror[token] == address(0)) revert();
-		if (mirrorVersions[mirror] == MIRROR_VERSION) revert();
-		_updateMirror(_mirror, _token);
-		//..........
-	}
+		// Note: There's no _token slot in this proxy
+		Proxy _mirror = address(new L2ChugSplashProxy{salt: keccak256(abi.encode(_token))}(address(this), _token));
 
-	function _updateMirror(address _mirror, address _token) internal {
-		mirrors[_token] = _mirror;
-		mirrorVersions[_mirror] = MIRROR_VERSION;
+		// Note: This function does not exist on L2ChugSplashProxy.
 		_mirror.setImplementation(MIRROR_IMPL);
 	}
 
-	// Note: we could fuse both functions into deployMirror.
-	// Separating them here for clarity.
+	function upgradeMirror(address _mirror) external {
+		// Note: This function does not exist on L2ChugSplashProxy.
+		_mirror.setImplementation(MIRROR_IMPL);
+	}
+
+	function _isOptimismMintableERC20(address _token) internal view returns (bool) {
+        return ERC165Checker.supportsInterface(_token, type(ILegacyMintableERC20).interfaceId)
+            || ERC165Checker.supportsInterface(_token, type(IOptimismMintableERC20).interfaceId);
+    }
+
+	function getMirrorAddress(address _token) external view returns (address _mirror) {
+		_mirror = address(uint160(uint(keccak256(abi.encodePacked(
+            bytes1(0xff),
+            address(this),
+            keccak256(abi.encode(_token)),
+            keccak256(abi.encodePacked(
+                type(L2ChugSplashProxy).creationCode,
+                abi.encode(_token)
+            ))
+        )))))
+	} 
 }
 
 ```
 
 # Risks & Uncertainties
 
-This only accounts for `OptimismMintableERC20Tokens`. The design space is limited for simplicity. Legacy tokens with different bytecodes are not considered. New interoperable tokens using the `Superc20` standard, which will have a different bytecode as well, are not taken into account for this factory.
+This only accounts for `OptimismMintableERC20Tokens`. The design space is limited for simplicity. Legacy tokens are not considered. New interoperable tokens using the `Superc20` standard without Mirrors, are not taken into account for this factory.
 
 If the design space were to be extended `Create3` and extra predeploys would be needed.
 
-Current `OptimismMintableERC20Tokens` deployed by OP and Ethereum mainnet factories have different versions and, therefore, different bytecodes. This should not be a problem as the Mirror does not care about these changes.
+Current `OptimismMintableERC20Tokens` deployed by OP and Ethereum mainnet factories have different versions and, therefore, different bytecodes. This should not be a problem as long as these tokens grant `burn` and `mint` permissions to the `StandardBridge` and conform to the `ERC20` interface.

--- a/protocol/superc20/mirror-factory-limited.md
+++ b/protocol/superc20/mirror-factory-limited.md
@@ -49,7 +49,7 @@ The mirror implementation contract should be deployed beforehand. The Proxy must
 This design allows the `StandardBridge` to call `mirrors(_token)` when a `Mirror` contract performs a `transfer` and validates the mirror belongs to the `_token`. As an illustrative example:
 
 ```solidity
-function mirrorMint(_token, amount) external {
+function mirrorMint(address _token, uint256 _amount) external {
 	address _mirror = MIRROR_FACTORY.mirrors(_token);
 	if (_mirror != msg.sender) revert();
 	///...mint logic


### PR DESCRIPTION
**Description**

This document describes a possible design for a new Factory predeploy capable of deploying `Mirror` contracts for `OptimismMintableERC20Token`s. 

**Additional Context**
The space for this design is limited to only `OptimismMintableERC20Token`s. 

