### PR TITLE
feat: Adding Mirror Factory with Create3

### DIFF
--- a/protocol/superc20/mirror-factory-limited.md
+++ b/protocol/superc20/mirror-factory-limited.md
@@ -62,24 +62,24 @@ contract MirrorERC20Factory is Semver {
   event MirrorDeployed(address indexed mirror, address indexed token);
 
   constructor() is Semver(1,0,0) {
-	implementation = new MirrorSuperchainERC20();
+    implementation = new MirrorSuperchainERC20();
   }
 
   function deploy(address _token) external returns (address _mirror) {
-	require(_isOptimismMintableERC20(_token), "not OptimismMintableERC20Token");
+    require(_isOptimismMintableERC20(_token), "not OptimismMintableERC20Token");
 
-	bytes memory _creationCode = abi.encodePacked(type(Proxy).creationCode, abi.encode(address(this), _token));
+    bytes memory _creationCode = abi.encodePacked(type(Proxy).creationCode, abi.encode(address(this), _token));
 
-	_mirror = CREATE3.deploy({salt: _token, creationCode: _creationCode, value: 0 });
+    _mirror = CREATE3.deploy({salt: _token, creationCode: _creationCode, value: 0 });
 
-	mirrors[_token] = _mirror;
+    mirrors[_token] = _mirror;
 
-	emit MirrorDeployed(_mirror, _token);
+    emit MirrorDeployed(_mirror, _token);
   }
 
   function _isOptimismMintableERC20(address _token) internal view returns (bool) {
-	return ERC165Checker.supportsInterface(_token, type(ILegacyMintableERC20).interfaceId)
-	|| ERC165Checker.supportsInterface(_token, type(IOptimismMintableERC20).interfaceId);
+    return ERC165Checker.supportsInterface(_token, type(ILegacyMintableERC20).interfaceId)
+    || ERC165Checker.supportsInterface(_token, type(IOptimismMintableERC20).interfaceId);
   } 
 }
 

--- a/protocol/superc20/mirror-factory-limited.md
+++ b/protocol/superc20/mirror-factory-limited.md
@@ -12,79 +12,72 @@ The factory must facilitate the creation of a single legitimate Mirror per `Opti
 
 # Alternatives Considered
 - Using `CREATE`. Discarded due to nonce dependability.
-- Using `CREATE3`. Viable, yet not preferred due to increased complexity.
+- Using `CREATE2`. This solution is viable as long as the creation code is never modified. Because this is not a guarantee, this alternative was discarded in favor of `CREATE3`.
 
 # Proposed Solution
 
-Limiting the scope to `OptimismMintableERC20Tokens` allows using `CREATE2` instead of `CREATE3`, which is more expensive and complex. This is because the variables CREATE2 uses to define the address of the deployed contract provides all the properties we need to maintain the same address accross chains and easily verify whether a mirror was deployed by the official factory or not:
+The factory will be a predeploy that will be in charge of:
+- Deploying the proxies behind the `Mirrors`.
+- Holding the `Mirror` implementation address.
+- Tracking what `Mirrors` it deployed.
 
-- `Salt`: If we use the `token` address, we can link the `Mirror` to this `token`. This will allow other contracts to know whether a caller is a legitimate `Mirror` or not.
-- `Sender Address`: In this case, it will be the Factory address itself, or the address of the factory's proxy. This works well, as it the factory can be deployed at the same address accross different chains. For chains in the superchain, it will be a predeploy. This predeploy, however, won't have a pretty address. Instead, it has to be deployed at the address where the L1 Factory is deployed so the address is maintained for all chains.
-- `Init Code`: The same proxy's init code must be used accross chains.
+The factory will use `CREATE3` for the deployment of the `Mirrors`. `CREATE3` relies on the address of the factory—which must be the same across the superchain—and on the chosen salt to determine the address where the `Mirror` will be deployed. It eliminates any ties with the `Mirror`'s creation code, which ensures the address calculation will stay the same should a change take place in a future upgrade. This implies that if the `token` is used as the salt, and the factory is the same across the superchain, then the address of the `Mirror` will be the same on all chains. This is a required property for the `Mirror'`s interoperability features to work correctly.
 
-The salt doesn't need to be more than the `OptimismMintableERC20Token` address. The `name` and `symbol`, and `decimals` can be fetched with the `token` address alone in the implementation. The factory will be the `Mirror`'s admin, and the proxy will have to either call `setStorage` immediately with the `token` at the time of deployment, or add a `TOKEN_SLOT` and update it on the constructor.
+Furthermore, the factory will hold the implementation address of the `Mirror`. In other words, it will act as beacon of all the `Mirrors` it deploys. This carries the benefit of allowing the implementation to be updated when the factory is upgraded and not requiring an extra predeploy to act as beacon.
 
-The factory should be upgradable or have setters to allow the modification of the implementations for the current `Mirrors`. The deployment and update of already-deployed `Mirrors` to new implementations should be open to anyone.
-
-We can track versioning through numbers or the addresses of the implementations used.
-
-This design allows the `StandardBridge` or any contract that needs to check the legitimacy of a `Mirror` to call `MIRROR_FACTORY.getMirrorAddress()` and validate whether the calling user is a mirror that corresponds to a given `token`. As an illustrative example of a potential function of the `StandardBridge`:
+Lastly, the factory will store every `Mirror` it deploys. This will allow integrating contracts to perform validate whether a `Mirror` is a child of the official factory or not. This is an example of how the `L2StandardBridge` could implement the check in the `mirrorMint` function required by the `Mirror Standard`:
 
 ```solidity
 function mirrorMint(address _token, uint256 _amount) external {
-	address _mirror = MIRROR_FACTORY.getMirrorAddress(_token);
-	if (_mirror != msg.sender) revert();
-	///...mint logic
+  address _mirror = MIRROR_FACTORY.mirrors(_token);
+  if (_mirror != msg.sender) revert();
+  /// rest of the logic
 }
 
 ```
+
+Having these characteristics in mind, at the time of deployment of the `Mirrors`, the factory address and the corresponding token will be passed appended to the creation code so they are interpreted as constructor arguments. The factory address is needed to tell the proxy where to look for the implementation, so it will act as the beacon, and the token is needed to tell the implementation what token is extending.    
 
 Example code:
 
 ```solidity
 contract MirrorFactory {
-	string public constant MIRROR_VERSION = "1.0.0";
-	Mirror public constant MIRROR_IMPL = <PLACEHOLDER_ADDRESS>;
+  string public constant MIRROR_VERSION = "1.0.0";
 
-	function deployMirror(address _token) external returns (address) {
-		require(_isOptimismMintableERC20(_token), "not OptimismMintableERC20Token");
+  address public implementation;
+  mapping(address token => address mirror) public mirrors;
 
-		// Note: There's no _token slot in this proxy
-		Proxy _mirror = address(new L2ChugSplashProxy{salt: keccak256(abi.encode(_token))}(address(this), _token));
+  event MirrorDeployed(address indexed mirror, address indexed token);
 
-		// Note: This function does not exist on L2ChugSplashProxy.
-		_mirror.setImplementation(MIRROR_IMPL);
-	}
+  constructor() {
+	implementation = new MirrorSuperchainERC20();
+  }
 
-	function upgradeMirror(address _mirror) external {
-		// Note: This function does not exist on L2ChugSplashProxy.
-		_mirror.setImplementation(MIRROR_IMPL);
-	}
+  function deploy(address _token) external returns (address _mirror) {
+	require(_isOptimismMintableERC20(_token), "not OptimismMintableERC20Token");
 
-	function _isOptimismMintableERC20(address _token) internal view returns (bool) {
-        return ERC165Checker.supportsInterface(_token, type(ILegacyMintableERC20).interfaceId)
-            || ERC165Checker.supportsInterface(_token, type(IOptimismMintableERC20).interfaceId);
-    }
+	bytes memory _creationCode = abi.encodePacked(type(Proxy).creationCode, abi.encode(address(this), _token));
 
-	function getMirrorAddress(address _token) external view returns (address _mirror) {
-		_mirror = address(uint160(uint(keccak256(abi.encodePacked(
-            bytes1(0xff),
-            address(this),
-            keccak256(abi.encode(_token)),
-            keccak256(abi.encodePacked(
-                type(L2ChugSplashProxy).creationCode,
-                abi.encode(_token)
-            ))
-        )))))
-	} 
+	_mirror = CREATE3.deploy({salt: _token, creationCode: _creationCode, value: 0 });
+
+	mirrors[_token] = _mirror;
+
+	emit MirrorDeployed(_mirror, _token);
+  }
+
+  function _isOptimismMintableERC20(address _token) internal view returns (bool) {
+	return ERC165Checker.supportsInterface(_token, type(ILegacyMintableERC20).interfaceId)
+	|| ERC165Checker.supportsInterface(_token, type(IOptimismMintableERC20).interfaceId);
+  } 
 }
 
 ```
+# Open Questions
+- Do we need to have versioning in the factory?
+- Is the `_isOptimismMintableERC20` check needed? The mirror of a token that doesn't grant the `L2StandardBridge` `burn` and `mint` permissions should be useless.
+- How will the Proxy behind the `Mirrors` look like? A modified ERC1967Proxy will be sufficient? Should we add its design to the Mirror Standard PR?
 
 # Risks & Uncertainties
 
 This only accounts for `OptimismMintableERC20Tokens`. The design space is limited for simplicity. Legacy tokens are not considered. New interoperable tokens using the `Superc20` standard without Mirrors, are not taken into account for this factory.
-
-If the design space were to be extended `Create3` and extra predeploys would be needed.
-
-Current `OptimismMintableERC20Tokens` deployed by OP and Ethereum mainnet factories have different versions and, therefore, different bytecodes. This should not be a problem as long as these tokens grant `burn` and `mint` permissions to the `StandardBridge` and conform to the `ERC20` interface.
+Current `OptimismMintableERC20Tokens` deployed by OP and Ethereum mainnet factories have different versions and, therefore, different bytecodes. This should not be a problem as long as these tokens grant `burn` and `mint` permissions to the `L2StandardBridge` and conform to the `ERC20` interface.

--- a/protocol/superc20/mirror-factory-limited.md
+++ b/protocol/superc20/mirror-factory-limited.md
@@ -2,13 +2,21 @@
 
 *The work present below is part of the [Interoperability project](https://github.com/ethereum-optimism/optimism/issues/10899).*
 
-A factory to spin up `ISuperchainERC20` Mirrors of `OptimismMintableERC20Tokens` is required. This document aims to provide a design for such a factory. The Mirrors need to be proxied to address any future addition of features. The factory will deploy these proxies. Therefore, from now on, when we say `Mirror` we refer to the Proxy and not the implementation.
+A new factory predeploy to spin up `ISuperchainERC20` `MirrorsERC20s` of `OptimismMintableERC20Tokens` is required. This document aims to provide a design for such a factory.
+
+# Overview
+
+- The `OptimismMintableERC20Factory` is a predeploy proxy with a corresponding implementation.
+- `OptimismMintableERC20Factory` deploys `OptimismMintableERC20` contracts. The `OptimismMintableERC20s` are not proxied.
+- The `MirrorERC20Factory` is a non-proxied predeploy. It deploys `MirrorERC20` tokens—which are proxied—using the beacon pattern. This allows upgrading all `MirrorERC20` implementations at once if needed.
+- The `MirrorERC20Factory` will act as the beacon for the `MirrorERC20s`.
+
 
 # Problem Statement + Context
 
-A vast amount of `OptimismMintableERC20Tokens` currently exist in the ecosystem. These tokens do not have interoperable properties. Therefore, they require a migration to become interoperable. The migration will be performed through Mirrors, as specified by [Mirror Standard](https://github.com/ethereum-optimism/design-docs/pull/36). These Mirrors must be easily deployed through a predefined factory to ensure all Mirrors share the same functionality and address across chains and also to verify their legitimacy.
+A vast amount of `OptimismMintableERC20Tokens` currently exist in the ecosystem. These tokens do not have interoperable properties. Therefore, they require a migration to become interoperable. The migration will be performed through `MirrorERC20s`, as specified by [Mirror Standard](https://github.com/ethereum-optimism/design-docs/pull/36). These `MirrorERC20s` must be easily deployed through a predefined factory to ensure they share the same functionality and address across chains and also to verify their legitimacy.
 
-The factory must facilitate the creation of a single legitimate Mirror per `OptimistismMintableERC20Token` to avoid liquidity fragmentation and unnecessary complexity.
+The factory must facilitate the creation of a single legitimate `MirrorERC20` per `OptimistismMintableERC20Token` to avoid liquidity fragmentation and unnecessary complexity.
 
 # Alternatives Considered
 - Using `CREATE`. Discarded due to nonce dependability.
@@ -36,20 +44,24 @@ function mirrorMint(address _token, uint256 _amount) external {
 
 ```
 
+For this to work and be secure, certain invariants must hold:
+- The factory MUST only deploy a single `Mirror` per token.
+- The factory MUST store ALL `Mirrors` it deploys. 
+- Upgrades must not modify the values in the `mirrors` mapping.
+
+
 Having these characteristics in mind, at the time of deployment of the `Mirrors`, the factory address and the corresponding token will be passed appended to the creation code so they are interpreted as constructor arguments. The factory address is needed to tell the proxy where to look for the implementation, so it will act as the beacon, and the token is needed to tell the implementation what token is extending.    
 
 Example code:
 
 ```solidity
-contract MirrorFactory {
-  string public constant MIRROR_VERSION = "1.0.0";
-
+contract MirrorERC20Factory is Semver {
   address public implementation;
   mapping(address token => address mirror) public mirrors;
 
   event MirrorDeployed(address indexed mirror, address indexed token);
 
-  constructor() {
+  constructor() is Semver(1,0,0) {
 	implementation = new MirrorSuperchainERC20();
   }
 
@@ -72,12 +84,18 @@ contract MirrorFactory {
 }
 
 ```
+
+# User Stories
+- A user wants an existing `OptimismMintableERC20Token` to become interoperable. To do this he can deploy the token's corresponding `MirrorERC20` by interacting with the `MirrorERC20Factory`.
+- A user creates an `OptimismMintableERC20Token` through the `OptimismMintableERC20Factory`. Later on, he, or any other user, can deploy its corresponding `MirrorERC20` token through the `MirrorERC20Factory`.
+- A user wants to make a token that does not comform to the `IOptimismMintableERC20` interface interoperable. The `MirrorERC20Factory` will not be of use, as it checks for this condition. Even if it were to deploy a `MirrorERC20Factory` for a token that fakes the interface compatibility, if that token does not give the `L2StandardBridge` permissions to `burn` and `mint`, its `transfer` and `transferFrom` functions would not work. 
+
 # Open Questions
+- Should the factory be proxied, or is it enough for it to be upgraded during hardforks?
 - Do we need to have versioning in the factory?
-- Is the `_isOptimismMintableERC20` check needed? The mirror of a token that doesn't grant the `L2StandardBridge` `burn` and `mint` permissions should be useless.
-- How will the Proxy behind the `Mirrors` look like? A modified ERC1967Proxy will be sufficient? Should we add its design to the Mirror Standard PR?
+- Is the `_isOptimismMintableERC20` check needed? The mirror of a token that doesn't grant the `L2StandardBridge` `burn` and `mint` permissions will have its `transfer` and `transferFrom` functions revert. So it will be useless. 
+- How will the Proxy behind the `Mirrors` look like? A modified BeaconProxy to accomodate for the token will be sufficient? Should we add its design to the Mirror Standard PR?
 
 # Risks & Uncertainties
 
-This only accounts for `OptimismMintableERC20Tokens`. The design space is limited for simplicity. Legacy tokens are not considered. New interoperable tokens using the `Superc20` standard without Mirrors, are not taken into account for this factory.
-Current `OptimismMintableERC20Tokens` deployed by OP and Ethereum mainnet factories have different versions and, therefore, different bytecodes. This should not be a problem as long as these tokens grant `burn` and `mint` permissions to the `L2StandardBridge` and conform to the `ERC20` interface.
+This only accounts for `OptimismMintableERC20Tokens`. Legacy tokens, that is tokens that implement the `ILegacyMintableERC20` interface will work as well. The design space is limited for simplicity. New interoperable tokens using the `Superc20` standard without Mirrors, are not taken into account for this factory. Tokens that don't comply to the `IOptimismMintableERC20` interface will not work with mirrors due to the permissions needed.


### PR DESCRIPTION
**Description**

This document describes a possible design for a new Factory predeploy capable of deploying Mirror contracts for OptimismMintableERC20Tokens using `CREATE3`

**Additional context**

Addresses the feedback provided to https://github.com/ethereum-optimism/design-docs/pull/37
