### PR TITLE
assets: apply comments to design doc guide/hints

### DIFF
--- a/assets/design-doc-template.md
+++ b/assets/design-doc-template.md
@@ -1,29 +1,42 @@
 # Purpose
 
-*This section is also sometimes called “Motivations” or “Goals”.*
+<!-- This section is also sometimes called “Motivations” or “Goals”. -->
 
-*It is fine to remove this section from the final document, but understanding the purpose of the doc when writing is very helpful.*
+<!-- It is fine to remove this section from the final document,
+but understanding the purpose of the doc when writing is very helpful. -->
 
 # Summary
 
-*Most (if not all) documents should have a summary. While the length will likely be proportional to the length of the full document, the summary should be as succinct as possible.*
+<!-- Most (if not all) documents should have a summary.
+While the length will likely be proportional to the length of the full document,
+the summary should be as succinct as possible. -->
 
 # Problem Statement + Context
 
-*Describe the specific problem that the document is seeking to address as well as information needed to understand the problem and design space. If more information is needed on the costs of the problem, this is a good place to that information.*
+<!-- Describe the specific problem that the document is seeking to address as well
+as information needed to understand the problem and design space.
+If more information is needed on the costs of the problem,
+this is a good place to that information. -->
 
 # Proposed Solution
 
-*A high level overview of the proposed solution. When there are multiple alternatives there should be an explanation of why one solution was picked over other solutions. As a rule of thumb, including code snippets (except for defining an external API) is likely too low level.*
+<!-- A high level overview of the proposed solution.
+When there are multiple alternatives there should be an explanation
+of why one solution was picked over other solutions.
+As a rule of thumb, including code snippets (except for defining an external API)
+is likely too low level. -->
 
 ## Resource Usage
 
-*What is the resource usage of the proposed solution? Does it consume a large amount of computational resources or time?*
+<!-- What is the resource usage of the proposed solution?
+Does it consume a large amount of computational resources or time? -->
 
 # Alternatives Considered
 
-*List out a short summary of each possible solution that was considered. Comparing the effort of each solution* 
+<!-- List out a short summary of each possible solution that was considered.
+Comparing the effort of each solution -->
 
 # Risks & Uncertainties
 
-*An overview of what could go wrong. Also any open questions that need more work to resolve.*
+<!-- An overview of what could go wrong.
+Also any open questions that need more work to resolve. -->


### PR DESCRIPTION
**Description**

Turn the design-doc guide / hints into HTML comments, and split nicely over multiple lines.
These don't render in the markdown, so now the writer can keep them around while writing their doc.


