### PR TITLE
update: fma superchainerc20

### DIFF
--- a/security/fma-superchainerc20-standard.md
+++ b/security/fma-superchainerc20-standard.md
@@ -16,23 +16,23 @@ Below are references for this project:
 - [Token standard specs](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/token-bridging.md).
 - [Implementation](https://github.com/defi-wonderland/optimism/tree/sc-feat/crosschain-erc20).
 
-It does not intend to cover related contracts such as `SuperchainERC20Bridge` or those involving migrated liquidity.
+It does not intend to cover related contracts such as `SuperchainTokenBridge` or those involving migrated liquidity.
 
 ## Failure Modes and Recovery Paths
 
 ### Unauthorized Access to `__crosschainMint` & `__crosschainBurn` Functions
 
-- **Description:** The `onlySuperchainERC20Bridge` modifier only allows `__crosschainMint` and `__crosschainBurn` to be callable by the `SuperchainERC20Bridge`. If the bridge address is badly defined or the modifier bypassed, an entity could mint and burn tokens.
+- **Description:** The `onlySuperchainTokenBridge` modifier only allows `__crosschainMint` and `__crosschainBurn` to be callable by the `SuperchainTokenBridge`. If the bridge address is badly defined or the modifier bypassed, an entity could mint and burn tokens.
 - **Risk Assessment**: Medium.
     - Potential impact: High. All tokens based on this implementation could be potentially at risk.
-    - Likelihood: Very Low. `Predeploys.SUPERCHAIN_ERC20_BRIDGE` are defined via protocol upgrades. The modifiers are sufficiently simple and battle-tested to give confidence in the implementation.
-- **Mitigation**: Ensure the `SuperchainERC20Bridge` is correctly set during deployment and isn’t subject to unexpected changes.
+    - Likelihood: Very Low. `Predeploys.SUPERCHAIN_TOKEN_BRIDGE` are defined via protocol upgrades. The modifiers are sufficiently simple and battle-tested to give confidence in the implementation.
+- **Mitigation**: Ensure the `SuperchainTokenBridge` is correctly set during deployment and isn’t subject to unexpected changes.
 - **Detection**: Existing off-chain scripts for token monitoring should be enough to detect any unauthorized mint or burn actions triggered by this method.
-- **Recovery Path(s)**: Equivocation on `SuperchainERC20Bridge` would require a protocol upgrade or hard fork. Very unlikely to need it.
+- **Recovery Path(s)**: Equivocation on `SuperchainTokenBridge` would require a protocol upgrade or hard fork. Very unlikely to need it.
 
 ### Different Token Addresses Across Chains
 
-- Description: For the `SuperchainERC20Bridge` to validate mints and burns correctly, the `SuperchainERC20` must be deployed at the same address across all interoperable chains. If different addresses are used, the bridge will be unable to successfully finalize the cross-chain transfer.
+- Description: For the `SuperchainTokenBridge` to validate mints and burns correctly, the `SuperchainERC20` must be deployed at the same address across all interoperable chains. If different addresses are used, the bridge will be unable to successfully finalize the cross-chain transfer.
 - Risk Assessment: Medium
     - Potential impact: High. Inconsistent token addresses will disable interoperability functionalities for the contract.
     - Likelihood: Very Low. The interoperable set of chains follows the same opcode behavior and ensures identical availability of deployer contracts, such as `create2Deployer`. Developers are encouraged not to use well-known flagged deployment methods, such as `CREATE`, for these purposes.
@@ -50,4 +50,4 @@ No audit should be required, as it is simple and isn’t expected to have depend
 
 ## Additional Notes
 
-The proposed implementation of the standard doesn’t prevent a token issuer from using other token standards, such as xERC20, with the `SuperchainERC20Bridge` to mint and burn tokens across an [interoperable set of chains](https://specs.optimism.io/interop/overview.html).
+The proposed implementation of the standard doesn’t prevent a token issuer from using other token standards, such as xERC20, with the `SuperchainTokenBridge` to mint and burn tokens across an [interoperable set of chains](https://specs.optimism.io/interop/overview.html).


### PR DESCRIPTION
**Description**

Reflecting a name change, updating the predeploy contract from `SuperchainERC20Bridge` to `SuperchainTokenBridge`.