### PR TITLE
Standardize Error Handling in Solidity

### DIFF
--- a/security/DeputyGuardianModule-Proxy.md
+++ b/security/DeputyGuardianModule-Proxy.md
@@ -1,0 +1,63 @@
+# Proxify the `DeputyGuardianModule`
+
+## Context
+
+![image](https://github.com/user-attachments/assets/466c7d28-f4d1-425d-82ec-eb1326287689)
+
+
+
+
+The `DeputyGuardianModule` is an important component for the Superchain security model. \
+The `DeputyGuardianModule`, also known as _DGM_, is a smart contract deployed on L1 (currently [here](https://etherscan.io/address/0xc6901f65369fc59fc1b4d6d6be7a2318ff38db5b)) that has, for example, the ability to widely pause the Superchain. \
+The `DGM` is owned by the _Foundation Operation Safe_ so only operation run from the _Foundation Operation Safe_ can be executed into the `DGM`. \
+To make sure we can widely pause the Superchain rapidly enough in case of an emergency, we need to presign the pause transaction from the signers of the _FoS_. \
+These transactions are also known as `PSP` for PreSigned Pause transactions. \
+This process requires a ceremony and this is slow and tedious to put in place.
+
+The list of available actions that the `DeputyGuardianModule` can execute are:
+| Function Name | Description |
+| ---------------------- | ---------------------------------------------------------- |
+| setRespectedGameType() | Change the current `gameType` used by the `OptimismPortal` |
+| blacklistDisputeGame() | Blacklist a disputeGame into the `OptimismPortal` |
+| unpause() | Unpause the withdrawal of the Superchain |
+| pause() | Pause the withdrawal of the Superchain |
+| setAnchorState()| Set a state into `AnchorStateRegistry` |
+
+
+## Problem Statement
+
+The existing `DeputyGuardianModule` is not _proxified_. \
+This is inconvenient each time we want to upgrade the `DeputyGuardianModule` to add a new feature or to fix a potential bug. \
+As this is not a proxy this require to redeploy the `DeputyGuardianModule` on L1. And also, to update the `Guardian` contract to add the new `DeputyGuardianModule` address as authorized module. \
+Moreover, changing the `DeputyGuardianModule` will break the current PSPs setup as these pause transactions are presigned with the **previous** `DeputyGuardianModule`. \
+Thus, we need to generate new PSPs through the tedious process of a ceremony to add the new `DeputyGuardianModule` for making the PSPs valid again. \
+We are clearly seeing that this is not a sustainable solution for the long term. 
+
+Additionally, we have to simulate the new PSPs and share them with other member of the Superchain.
+
+## Proposed Solution
+
+![image](https://github.com/user-attachments/assets/099258f4-19fb-44b8-84e9-670b78a2f868)
+
+Here we propose some modification of the architecture with a proxy contract on top of the `DeputyGuardianModule`, this will allow us to upgrade the `DeputyGuardianModule` and keeping the same address.
+Thus, this will not invalidate the PSPs and we will not need to regenerate new PSPs each time we upgrade the `DeputyGuardianModule`.
+
+The owner of the proxy contract `DeputyGuardianModuleProxy` would be the `Security Council` as the `DeputyGuardianModule` is doing action into the `Guardian` contract that is owned by the `Security Council`.
+This will means that only the security council would be able to upgrade the implementation of the `DeputyGuardianModuleProxy`.
+
+In this solution, we propose to follow the current proxy standard used by the rest of the contracts. 
+
+## Alternatives Considered
+
+No other alternatives were considered for now.
+
+## Risks & Uncertainties
+
+### Security Model
+
+We don't see any particular risk with this current design for the long term as this is a common pattern to use a proxy contract for upgrading a contract.
+
+A potential issue can occur with the PSPs coverage.
+During the upgrade the PSPs are going to be invalid so we need to make sure to presign new PSPs with the new `DeputyGuardianModuleProxy` address and simulate the PSPs accordingly.
+
+Now, we are using a proxy executing the same actions than before will cost a more gas. We should ensure there no previous call that can run out of gas (really unlikely).

--- a/solidity/revert-strings-to-custom-error-migration.md
+++ b/solidity/revert-strings-to-custom-error-migration.md
@@ -1,0 +1,25 @@
+# Purpose
+
+The purpose of this document is to standardize all error messages / handling for the Optimism Smart Contracts, which current use a mix of error strings, and mix both `require` and `revert`.
+
+# Summary
+
+All error messages going forward should use the prefix of the `contract` name, and the suffix of `*Error`. Additionally, all errors should be returned via `revert` rather than through the use of `require`. This is both for visual clarity, and due to the efficiency concerns around `require` in the case of errors with arguments.
+
+# Problem Statement + Context
+
+The current problem is the Optimism smart contracts mix both `require` and `revert` statements inconsistently with error strings, and Solidity custom errors. For the sake of a consistent abi the Optimism smart contracts should converge on a single method for reverting.
+
+# Alternatives Considered
+
+## Require and Error Strings
+
+All errors could be handled using `require` statements with error strings, however the main issue with this approach is that error strings take up significantly more bytecode size, and given the small margins of the contract size for staying within the Spurious Dragon bytecode size limit, it would be very useful to cut down on contract size in favor of more optimizer runs.
+
+## Require and Custom Errors
+
+As of Solidity 0.8.24, `require` supports using custom errors, however due the limitation that `require` does not short-circuit (ie if there is a custom error which has a value passed in, and you pass in the result of some function call to that argument, the function call will be executed regardless of whether or not the error is returned) meaning that in all cases it is inefficient, and in some cases even dangerous.
+
+# Proposed Solution - Revert and Custom Errors
+
+All errors returned from Optimism Smart Contracts should use `revert` with custom errors for both efficiency and safety. In the case of scripts and tests which currently use `require` frequently, they should be instead replaced with `assertEq` or similar `assert*` where appropriate, including a string as a revert message. This will allow for semgrep rules to more easily enforce the no `require` constraint. Custom errors should also include the contract name as a prefix, and `Error` as a suffix for clarity and consistency.


### PR DESCRIPTION

**Description**

Initial draft of my design doc to standardize error messages inside of the Optimism smart contracts.

**Tests**

No tests needed

**Additional context**

Carried over from discord thread discussion, main concern of removing `require` entirely was within tests, but consensus was reached around replacing it with `assertEq`.

**Metadata**
No Github Issues were made
