### PR TITLE
design doc for 'Always using _disableInitializers()  in constructors'

### DIFF
--- a/protocol/disableInitializers-in-constructor.md
+++ b/protocol/disableInitializers-in-constructor.md
@@ -46,4 +46,6 @@ No other alternatives considered.
 
 ## Risks, Uncertainties, and Considerations
 
-No risks, uncertainties or considerations found.
+### Consideration
+
+- Another rule that might help this proposal is asserting via Semgrep that all `initialize()` functions have an `external` modifier and there's no occurence of `this.initialize()`. This would help in enforcing this rule. Is there any scenario where `initialize()` functions need to be called from within a contract or an inheriting contract?


### PR DESCRIPTION
This design doc proposes always using `_disableInitializers()` in proxied contracts constructors rather than the prevalent approach of calling the `initialize()` function from the constructor.

Issue: https://github.com/ethereum-optimism/optimism/issues/12634