### PR TITLE
typo correction in documentation files

### DIFF
--- a/protocol/interoperable-ether.md
+++ b/protocol/interoperable-ether.md
@@ -30,14 +30,14 @@ This means that the new `WETH` predeploy allows for cross chain transfers.
 The main problem with this solution is the fact that it will break liquidity for wrapped `ether` into
 2 different contracts. Many applications already exist today that integrate with the existing predeploy.
 This will be annoying, but it should be very simple to migrate from the old `WETH` to the new `WETH`.
-Its a simple unwrap and wrap, and technically we could build support directly into the new `WETH` contract
+It's a simple unwrap and wrap, and technically we could build support directly into the new `WETH` contract
 to make the migration extra simple.
 
 An important problem to solve is ensuring that there are no liquidity constraints. If a wrap/unwrap mechanism
 is used rather than a mint/burn mechanism, it will result in liquidity constraints. Therefore we prefer a 
 mint/burn mechanism. We need a solution to the liquidity constraint that specifically happens when a user is
 trying to send ether to a remote domain. They have to wrap the ether into weth and then it gets sent between
-chains as weth and then we need to unwrap the weth. Its possible that there isn’t enough weth to unwrap on the other side.
+chains as weth and then we need to unwrap the weth. It's possible that there isn’t enough weth to unwrap on the other side.
 
 We introduce 2 new predeploys
 

--- a/protocol/op-node-derivers.md
+++ b/protocol/op-node-derivers.md
@@ -144,7 +144,7 @@ To integrate interop in the op-node as-is, we would have to:
 - Modify the various forkchoice-updates of EngineController to be consistent with the cross-unsafe head.
 - Modify the engine-queue/controller to allow reorgs through a different path than the current block-attributes path.
 - Modify the find-sync-start loop to add a block tag of cross-unsafe.
-- Modify the driver to accomodate for a special-purpose process that maintains a view of the cross-L2 safety,
+- Modify the driver to accommodate for a special-purpose process that maintains a view of the cross-L2 safety,
   while explicitly synchronizing the engine-control access in the main state-loop.
 
 This is high-effort (medium in size, but hard to test), and accumulates a lot more tech-debt,

--- a/protocol/proofs/fdg-refund-mode.md
+++ b/protocol/proofs/fdg-refund-mode.md
@@ -13,7 +13,7 @@ can be manually disbursed to the correct recipients.
 
 Although `DelayedWETH` is an effective tool at preventing a buggy or malicious `FaultDisputeGame`
 from distributing bonds to a potential attacker, the actual process of returning those bonds back
-to the correct players is underspecified. Underspecified proceses can introduce significant stress
+to the correct players is underspecified. Underspecified processes can introduce significant stress
 to already stressful situations where executive decisions around fallbacks must be made quickly and
 confidently. We therefore want to introduce alternative low-stress options for bond recovery.
 

--- a/protocol/standard-l2-genesis.md
+++ b/protocol/standard-l2-genesis.md
@@ -133,7 +133,7 @@ This role will be set in `SystemConfig.initialize()`, meaning that it can only b
 In summary:
 
 1. The `FeeAdmin` can update the `FeeConfig`.
-2. The Upgrade Controller (aka [L1 ProxyAdmin Owner](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/stage-1.md#configuration-of-safes)) Safe cand update the `FeeAdmin`.
+2. The Upgrade Controller (aka [L1 ProxyAdmin Owner](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/stage-1.md#configuration-of-safes)) Safe can update the `FeeAdmin`.
 
 #### L2ProxyAdmin
 

--- a/security/fma-fjord.md
+++ b/security/fma-fjord.md
@@ -34,7 +34,7 @@ This document is intended to be shared in a public space for reviews and visibil
 - enables a precompile for the secp256r1 elliptic curve ([RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md))
 - a more accurate L1 data cost function that estimates the batch-compressed transaction size using a [FastLZ](https://code.google.com/archive/p/fastlz/) based linear regression.
 - Introduces Brotli as new channel compression algo
-- Increase max-sequencer-drift to 30 minutes
+- Increase the max-sequencer-drift to 30 minutes
 - 10x the max rlp bytes per channel and max channel bank size
     - Impl: https://github.com/ethereum-optimism/optimism/pull/10357
 
@@ -81,7 +81,7 @@ Fjord introduces changes to the `GasPriceOracle` precompile contract on the L2. 
 
 - **Mitigations:** Unit and end-to-end testing, extensive evaluation of the cost function showing far better robustness in minimizing estimation error compared to what has been used pre-Fjord.
 
-- **Detection:** Dashboards would quickly reveal if we are charging too little and alerts should fire if we are no longer recovering revenue from L1 data posting. L1 fee parameters are tuned to maintain a 5% margin above expected cost. If we are charging too much then we’ll observe revenue recovery well above this margin, and could even here reports from users/dApp operators. Chains such as Base have alerts set to fire If we are charging too little and revenue recovery goes below 0.
+- **Detection:** Dashboards would quickly reveal if we are charging too little and alerts should fire if we are no longer recovering revenue from L1 data posting. L1 fee parameters are tuned to maintain a 5% margin above expected cost. If we are charging too much then we’ll observe revenue recovery well above this margin, and could even hear reports from users/dApp operators. Chains such as Base have alerts set to fire If we are charging too little and revenue recovery goes below 0.
 
 - **Recovery Path(s)**: Fjord preserves the ability to adjust fee recovery margin via fee scalar and blob fee scalars should we be under or over charging
 
@@ -89,7 +89,7 @@ Fjord introduces changes to the `GasPriceOracle` precompile contract on the L2. 
 
 - **Description:** The 7212 precompile may not get activated properly at the point of the hardfork, or it may be activated properly but there may be bugs in the implementation.
 
-- **Risk Assessment:** Low.  If 7212 fails to deploy, since there are no existing uses of it, there will be no immediate impact. The impact is in prohibiting future potential uses of this predeploy. If the issue is a bug in the implementation, then users could end up trying to use it anyway and get incorrect results.  The implementation however is the reference implementation that has been been vetted by the broader community, so this outcome is unlikely.
+- **Risk Assessment:** Low.  If 7212 fails to deploy, since there are no existing uses of it, there will be no immediate impact. The impact is in prohibiting future potential uses of this predeploy. If the issue is a bug in the implementation, then users could end up trying to use it anyway and get incorrect results.  The implementation however is the reference implementation that has been vetted by the broader community, so this outcome is unlikely.
 
 - **Mitigations:** Precompiles activate new code paths and do not require dynamic deployment of new contract code, which implies the risk is lower than a predeploy update.  Mitigations mostly involve e2e testing, and vetting activation in our dev & testnets.  The 7212 implementation itself that we are using has been extensively tested and vetted not only by us but also the broader community.
 

--- a/security/fma-generic-hardfork.md
+++ b/security/fma-generic-hardfork.md
@@ -51,7 +51,7 @@ Since there is no chain halt, we can just live with it and fix it in an upcoming
 
 #### Activation Failure without chain halt: Node software
 
-- **Description:** The upgrade may be misconfigured in the node software (e.g. superchain-registy dependency was not updated) and fail to take place.
+- **Description:** The upgrade may be misconfigured in the node software (e.g. superchain-registry dependency was not updated) and fail to take place.
 
 - **Risk Assessment:** Low severity if there were no L1 contract changes or if there were L1 contract changes but they also failed to apply, since the chain would continue on as if the upgrade never happened. 
 

--- a/security/fma-holocene.md
+++ b/security/fma-holocene.md
@@ -51,7 +51,7 @@ This document is intended to be shared in a public space for reviews and visibil
 - (Execution Layer & Smart Contracts) Configurable EIP-1559 Parameters via SystemConfig
 - (Smart Contracts) Update to the MIPS contract
 
-Each change has it's own section below with a list of Failure Modes.
+Each change has its own section below with a list of Failure Modes.
 
 Below are references for this project:
 


### PR DESCRIPTION
**Description**
Corrected "accomodate" to "accommodate".
Corrected "proceses" to "processes".
Corrected "cand" to "can".
Corrected "here" to "hear".
Corrected "registy" to "registry" and much more.

**Additional context**
This pull request contains changes to improve clarity, correctness and structure. Please review the changes and let me know if any additional changes are needed.
