### PR TITLE
rename `l1ContractsVersion` to `l1ContractsRelease`

### DIFF
--- a/protocol/op-contracts-manager-single-release-redesign.md
+++ b/protocol/op-contracts-manager-single-release-redesign.md
@@ -10,7 +10,7 @@ OPCM will transition from its current singleton architecture to a multi-deployme
 
 - Remove the [proxy](https://github.com/ethereum-optimism/optimism/blob/4c015e3a36f8910e2cf8b447d62ab4c44b944cca/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol#L545) from OPCM.
 - Remove [initialize](https://github.com/ethereum-optimism/optimism/blob/28283a927e3124fa0b2cf8d47d1a734e95478215/packages/contracts-bedrock/src/L1/OPContractsManager.sol#L210) functionality from OPCM and introduce standard constructor initialization.
-- Add versioning to OPCM to expose which L1 contracts are deployed for the specific OPCM deployment e.g. `string constant l1ContractsVersion = "op-contracts/v1.6.0";` or something more nuanced that shows the relationship between the version string and the [standard release implementation addresses](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-versions-mainnet.toml#L9). This versioning is in addition to the [existing semvers](https://github.com/ethereum-optimism/optimism/blob/feat/isthmus-contracts/packages/contracts-bedrock/src/L1/OPContractsManager.sol#L133-L134) that exist on OPCM contracts today.
+- Add versioning to OPCM to expose which L1 contracts are deployed for the specific OPCM deployment e.g. `string constant l1ContractsRelease = "op-contracts/v1.6.0";` or something more nuanced that shows the relationship between the version string and the [standard release implementation addresses](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-versions-mainnet.toml#L9). This versioning is in addition to the [existing semvers](https://github.com/ethereum-optimism/optimism/blob/feat/isthmus-contracts/packages/contracts-bedrock/src/L1/OPContractsManager.sol#L133-L134) that exist on OPCM contracts today.
 - Update `op-deployer`, `DeploySuperchain.s.sol`, `DeployImplementations.s.sol` and `DeployOPChain.s.sol` to work with the new multi-deployment paradigm of one OPCM per L1 smart contract release.
 
 
@@ -37,7 +37,7 @@ With every official L1 smart contract release[^1], OPCM will need to be deployed
 string public constant version = "3.1.0"; // <-- normal semver consistent with all Optimism smart contracts
 
 // @notice L1 smart contracts release deployed by this version of OPCM.
-string constant l1ContractsVersion = "op-contracts/v3.1.0"; // <-- opcm specific
+string constant l1ContractsRelease = "op-contracts/v3.1.0"; // <-- opcm specific
 ```
 
 # Proposed Solution


### PR DESCRIPTION
This PR makes the naming consistent with the code [here](https://github.com/ethereum-optimism/optimism/blob/d784a98b34e28866b4ddbe2f46fb0b59ce95e6ba/packages/contracts-bedrock/src/L1/OPContractsManager.sol#L132).