### PR TITLE
feat: Add FMA SuperchainWETH

### DIFF
--- a/security/fma-superchainweth.md
+++ b/security/fma-superchainweth.md
@@ -1,4 +1,4 @@
-# [DRAFT] FMA - SuperchainWETH
+# SuperchainWETH: Failure Modes and Recovery Path Analysis
 
 | Author | Joxes, Gotzen, Parti |
 | --- | --- |

--- a/security/fma-superchainweth.md
+++ b/security/fma-superchainweth.md
@@ -1,0 +1,108 @@
+# [DRAFT] FMA - SuperchainWETH
+
+| Author | Joxes, Gotzen, Parti |
+| --- | --- |
+| Created at | 2025-01-10 |
+| Initial Reviewers | Pending |
+| Needs Approval From | Pending |
+| Status | In Review |
+
+## Introduction
+
+This document covers the addition of SuperchainWETH, an interop-enabled version of the WETH contract that allows ETH to be moved across a set of interoperable chains. SuperchainWETH is an ERC20 contract compliant with the ERC-7802 standard and complies with the same address property. The following components are included:
+
+- **Contracts**:
+    - Introduction of the `SuperchainWETH` predeploy proxy and implementation contract. It allows to wrapping ETH into SuperchainWETH and contains the logic to allow direct ETH interop transfers ETH.
+    - Introduction of the `ETHLiquidity` predeploy proxy and implementation contract, designed to ensure the conversion of SuperchainWETH into native ETH when the supply increases upon calling `crosschainMint`, by maintaining a large reserve of native ETH.
+
+Below are references for this project:
+
+- Design doc:
+    - Introduction of SuperchainWETH: https://github.com/ethereum-optimism/design-docs/blob/main/protocol/interoperable-ether.md
+    - Handling SuperchainWETH transfers: https://github.com/ethereum-optimism/design-docs/blob/main/protocol/interoperable-ether-transfers.md
+- Specs: https://github.com/ethereum-optimism/specs/blob/main/specs/interop/superchain-weth.md
+- Implementation:
+    - `SuperchainWETH`: https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/SuperchainWETH.sol
+    - `ETHLiquidity`: https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/ETHLiquidity.sol
+
+
+>🗂️ **For more context about the Interop project, refer to the following docs:**
+> 1. [Interop System Diagram](https://www.notion.so/16c8052fcbb24b93ad1a539b5f8db4c1?pvs=21)
+> 2. [Interop PID](https://www.notion.so/16c8052fcbb24b93ad1a539b5f8db4c1?pvs=21)
+> 3. [Interop Audit Request](https://docs.google.com/document/d/1Rcuzbsguh7koT2jFru5ft9T8zAvjBEzbt0zF5LNQQ08/edit?tab=t.0)
+
+
+
+## Failure Modes and Recovery Paths
+
+### FM1: Can call `sendETH` in a Custom Gas Token chain due to `isCustomGasToken`  returning `false`
+
+- **Description:** The `sendETH` function requires `IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isCustomGasToken()` to return `true` for chains where a custom gas token is used. If this check is improperly implemented, returning `false`, the system might incorrectly allow `sendETH` calls on chains using a custom gas token.
+- **Risk Assessment:** High.
+    - Potential Impact: High. If the call succeeds on a chain that uses a custom gas token version, it could allow for the possibility of minting native ETH at the destination. There would be economic reasons to do so if the issue is found to be exploitable.
+    - Likelihood: Low. The checker logic is simple enough and `L1Block` exposes this value at every moment, but misconfigurations may occur.
+- **Mitigations:** Ensure `sendETH` checks are implemented correctly and ensure `isCustomGasToken` in L1Block is correctly configured after initialization. The sequencer in the destination chain should not validate any `relayETH` that comes from a `sendETH` call originating in a custom gas token chain.
+- **Detection:** Off-chain monitoring scripts should flag `SendETH` events from custom gas token chains. The `op-supervisor` should detect such a situation within the invariants checks.
+- **Recovery Path(s):** Coordinate an L2 hard fork to revert the subsequent states derived from the failure, and upgrade the predeploy contracts to patch the issue. Pause the system via `SuperchainConfig` if a withdrawal is at risk to finalize. Notify service providers that may be impacted by this failure such as bridges, oracles, and exchanges.
+
+### FM2: Can not call `sendETH` or `crosschainMint` in native ETH chains due to `isCustomGasToken` returning `true`
+
+- **Description:** The `sendETH` and `crosschainMint` function requires `IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isCustomGasToken()` to return `false` for chains where ETH is the native token. If this check is improperly implemented, returning `true`, the system might incorrectly deny `sendETH` or `crosschainMint` calls on chains using ETH as native asset.
+- **Risk Assessment:** Medium.
+    - Potential Impact: Medium. If the call revert, it would deny to send ETH and SuperchainWETH to other chains.
+    - Likelihood: Low. The checker logic is simple enough and `L1Block` exposes this value at every moment, but misconfigurations may occur.
+- **Mitigations:** Ensure `isCustomGasToken` in L1Block is correctly configured after initialization.
+- **Detection:** Off-chain monitoring scripts should flag `SendETH` and `crosschainMint` events that reverts with custom error `isCustomGasToken` on chains that should be ETH native.
+- **Recovery Path(s):** Upgrade `L1Block` contracts to properly configure `isCustomGasToken`.
+
+### FM3: Can call `deposit` or `withdraw` in a Custom Gas Token chain due to `isCustomGasToken` returning `false`
+
+- **Description:** The `deposit` and `withdraw` functions require `IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isCustomGasToken()` to return `true` for chains where a custom gas token is used. If this check is improperly implemented, returning `false`, the system might incorrectly allow to obtain SuperchainWETH.
+- **Risk Assessment:** High.
+    - Potential Impact: High. If the `deposit` call succeeds on a chain that uses a custom gas token version, it could allow for the possibility of minting SuperchainWETH using a custom gas token. There would be economic reasons to do so if the issue is found to be exploitable. The `withdraw` function is less susceptible since it requires storing native liquidity beforehand, and the custom gas token must be more valuable than SuperchainWETH. This would discourage certain types of economic attacks.
+    - Likelihood: Low. The checker logic is simple enough and `L1Block` exposes this value at every moment, but misconfigurations may occur.
+- **Mitigations:** Ensure `deposit` and `withdraw` checks are implemented correctly and `isCustomGasToken` in L1Block is correctly configured after initialization.
+- **Detection:** Off-chain monitoring scripts should flag `Deposit` and `Withdrawal` events from custom gas token chains.
+- **Recovery Path(s):** Coordinate an L2 hard fork to revert the subsequent states derived from the failure, and upgrade the predeploy contracts to patch the issue. Pause the system via `SuperchainConfig` if a withdrawal is at risk to finalize. Notify service providers that may be impacted by this failure such as bridges, oracles, and exchanges.
+
+### FM4: Can not call `deposit` or `withdraw` in native ETH chains due to `isCustomGasToken` returning `true`
+
+- **Description:** The `deposit` and `withdraw` function requires `IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isCustomGasToken()` to return `false` for chains where ETH is the native token. If this check is improperly implemented, returning `true`, the system might incorrectly deny `deposit` or `withdraw` calls between native ETH and SuperchainWETH.
+- **Risk Assessment:** Medium.
+    - Potential Impact: Medium. If any of those calls revert, it would deny to convert between native ETH and SuperchainWETH.
+    - Likelihood: Low. The checker logic is simple enough and `L1Block` exposes this value at every moment, but misconfigurations may occur.
+- **Mitigations:** Ensure `isCustomGasToken` in L1Block is correctly configured after initialization.
+- **Detection:** Off-chain monitoring scripts should flag `Deposit` and `Withdraw` events that revert with custom error `isCustomGasToken` on chains that should be ETH native.
+- **Recovery Path(s):** Upgrade `L1Block` contracts to properly configure `isCustomGasToken`.
+
+### FM5: Insufficient ETH in `ETHLiquidity`
+
+- **Description:** If `ETHLiquidity` lacks sufficient ETH, `mint` calls will revert when the contract attempts to forward funds using `SafeSend`. This breaks bridging flows dependent on `relayETH`  and `crosschainMint`.
+- **Risk Assessment:** Medium.
+    - Potential Impact: Medium. Not having enough ETH balance in `ETHLiquidity` prevents relaying ETH or cross minting SuperchainWETH, which would degrade the user experience.
+    - Likelihood: Very low. `ETHLiquidity` starts with a maximum balance (`type(uint248).max`).
+- **Mitigations:** Ensure initial ETH supply in `ETHLiquidity` is `type(uint248).max` after initial config.
+- **Detection:** Existing off-chain scripts should detect if multiple `mint` calls revert. Additionally, check the current `ETHLiquidity` balance. Ensure that the lack of ETH is not due to other failures detailed in this document.
+- **Recovery Path(s):** Coordinate an L2 hard fork to replenish the `ETHLiquidity` contract. Investigate the causes of the depletion to determine if other factors are involved.
+
+### Generic items we need to take into account:
+
+See [fma-generic-contracts.md](https://github.com/ethereum-optimism/design-docs/blob/main/security/fma-generic-contracts.md).
+
+- [x]  Check this box to confirm that these items have been considered and updated if necessary.
+
+See [relevant FMAs to SuperchainWETH, To Do] 
+
+- [ ]  Check this box to confirm that these items have been considered and updated if necessary.
+
+## Action Items
+
+- [ ]  Resolve all the comments.
+- [ ]  Proceed with the code implementation and make any necessary approved changes.
+- [ ]  Move into testing of all the components.
+- [ ]  Make sure there are monitoring solutions ready to cover all the cases.
+- [ ]  **Ensure that the actions items specified in each FMAs on which SuperchainWETH depends are completed.**
+
+## Audit Requirements
+
+Following the [Audit Framework](https://gov.optimism.io/t/op-labs-audit-framework-when-to-get-external-security-review-and-how-to-prepare-for-it/6864), SuperchainWETH fits within the second budget, which includes smart contract code that secures assets. That means the `SuperchainWETH.sol` and `ETHLiquidity.sol` and associated interop contract dependencies (`CrossL2Inbox`, `L2ToL2CrossDomainMessenger`, `SuperchainTokenBridge`, `L1BlockInterop`, `SystemConfigInterop`, `OptimismPortalInterop`) require an audit before going to production.

--- a/security/fma-superchainweth.md
+++ b/security/fma-superchainweth.md
@@ -39,7 +39,7 @@ Below are references for this project:
 
 - **Description:** If `ETHLiquidity` lacks sufficient ETH, mint calls will revert when the contract attempts to forward funds using `SafeSend`. This breaks bridging flows dependent on `relayETH`  and `crosschainMint`.
 - **Risk Assessment:** Medium.
-    - Potential Impact: High. Not having enough ETH balance in `ETHLiquidity` prevents relaying ETH or mint SuperchainWETH through `crosschainMint`, which would greatly degrade the user experience, as they would be temporarily stuck.
+    - Potential Impact: High. Not having enough ETH balance in `ETHLiquidity` prevents relaying ETH or mint SuperchainWETH through `crosschainMint`, which would greatly degrade the user experience, as they would be temporarily stuck. The situation becomes even more serious if the affected cross-chain messages expire before the issue can be resolved, making it impossible to retry the relay and get the funds in destination chain.  
     - Likelihood: Very low. `ETHLiquidity` starts with a maximum balance (`type(uint248).max`).
 - **Mitigations:** Our current codebase includes tests to check if the `mint` request exceeds the contract’s balance ([test](https://github.com/ethereum-optimism/optimism/blob/dd37e6192c37ed4c5b18df0269f065f378c495cc/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol#L103)). Initial ETH supply in `ETHLiquidity` is `type(uint248).max` ([test](https://github.com/ethereum-optimism/optimism/blob/dd37e6192c37ed4c5b18df0269f065f378c495cc/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol#L29)) and equally set in all chains.
 - **Detection:** Perform checks on the `ETHLiquidity` balance as a preventive monitoring measure. User-filed support tickets may flag this issue in case of failure.

--- a/security/fma-superchainweth.md
+++ b/security/fma-superchainweth.md
@@ -5,7 +5,7 @@
 | Created at | 2025-01-10 |
 | Initial Reviewers | Kelvin Fichter, Michael Amadi |
 | Needs Approval From | Kelvin Fichter |
-| Status | In Review |
+| Status | Implementing Actions |
 
 ## Introduction
 

--- a/security/fma-superchainweth.md
+++ b/security/fma-superchainweth.md
@@ -42,7 +42,7 @@ Below are references for this project:
     - Potential Impact: Medium. Not having enough ETH balance in `ETHLiquidity` prevents relaying ETH or mint SuperchainWETH through `crosschainMint`, which would degrade the user experience.
     - Likelihood: Very low. `ETHLiquidity` starts with a maximum balance (`type(uint248).max`).
 - **Mitigations:** Our current codebase includes tests to check if the `mint` request exceeds the contract’s balance ([test](https://github.com/ethereum-optimism/optimism/blob/dd37e6192c37ed4c5b18df0269f065f378c495cc/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol#L103)). Initial ETH supply in `ETHLiquidity` is `type(uint248).max` ([test](https://github.com/ethereum-optimism/optimism/blob/dd37e6192c37ed4c5b18df0269f065f378c495cc/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol#L29)) and equally set in all chains.
-- **Detection:** Ideally, off-chain scripts should detect if multiple `mint` calls revert. Additionally, check the current `ETHLiquidity` balance. If that’s not feasible, user-filed support tickets may flag this issue, since funds are not at risk of loss due to this failure.
+- **Detection:** Perform checks on the `ETHLiquidity` balance as a preventive monitoring measure. User-filed support tickets may flag this issue in case of failure.
 - **Recovery Path(s):** Coordinate an L2 hard fork to replenish the `ETHLiquidity` contract. Investigate the causes of the depletion to determine if other factors are involved.
 
 ### FM2: Overflow during `burn` in `ETHLiquidity` due to max Balance
@@ -52,7 +52,7 @@ Below are references for this project:
     - Potential Impact: Medium. Reverts during `sendETH` calls are expected when the requested amount exceeds the maximum value representable by a `uint256`.
     - Likelihood: Very low. `ETHLiquidity` starts with a maximum balance (`type(uint248).max`) which is still far from `uint256` limit.
 - **Mitigations:** Initial ETH supply in `ETHLiquidity` is `type(uint248).max` properly is checked ([test](https://github.com/ethereum-optimism/optimism/blob/dd37e6192c37ed4c5b18df0269f065f378c495cc/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol#L29)).
-- **Detection:** Given the unlikely nature and potential impact of this case, user-filed support tickets should be sufficient to flag this issue since funds are not at risk of loss due to this failure.
+- **Detection:** Perform checks on the `ETHLiquidity` balance as a preventive monitoring measure. User-filed support tickets may flag this issue in case of failure.
 - **Recovery Path(s):** Coordinate an L2 hard fork to adjust the `ETHLiquidity` contract’s state. Investigate the causes of this failure to determine if other factors are involved.
 
 ### Generic items we need to take into account:
@@ -67,8 +67,8 @@ See [relevant FMAs to SuperchainWETH, To Do]
 
 ## Action Items
 
-- [ ]  Resolve all the comments.
-- [ ]  FM1: Decide whether to use off-chain scripts or rely on a user-support system for detection.
+- [x]  Resolve all the comments.
+- [ ]  FM1, FM2: Establish a balance monitoring measure in `ETHLiquidity` (optional).
 - [ ]  Ensure the support team is aware of these failure modes and prepared to respond.
 - [ ]  **Ensure that the actions items specified in each FMAs on which SuperchainWETH depends are completed.**
 

--- a/security/fma-superchainweth.md
+++ b/security/fma-superchainweth.md
@@ -38,12 +38,12 @@ Below are references for this project:
 ### FM1: Insufficient ETH in `ETHLiquidity`
 
 - **Description:** If `ETHLiquidity` lacks sufficient ETH, mint calls will revert when the contract attempts to forward funds using `SafeSend`. This breaks bridging flows dependent on `relayETH`  and `crosschainMint`.
-- **Risk Assessment:** Low.
-    - Potential Impact: Medium. Not having enough ETH balance in `ETHLiquidity` prevents relaying ETH or mint SuperchainWETH through `crosschainMint`, which would degrade the user experience.
+- **Risk Assessment:** Medium.
+    - Potential Impact: High. Not having enough ETH balance in `ETHLiquidity` prevents relaying ETH or mint SuperchainWETH through `crosschainMint`, which would greatly degrade the user experience, as they would be temporarily stuck.
     - Likelihood: Very low. `ETHLiquidity` starts with a maximum balance (`type(uint248).max`).
 - **Mitigations:** Our current codebase includes tests to check if the `mint` request exceeds the contract’s balance ([test](https://github.com/ethereum-optimism/optimism/blob/dd37e6192c37ed4c5b18df0269f065f378c495cc/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol#L103)). Initial ETH supply in `ETHLiquidity` is `type(uint248).max` ([test](https://github.com/ethereum-optimism/optimism/blob/dd37e6192c37ed4c5b18df0269f065f378c495cc/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol#L29)) and equally set in all chains.
 - **Detection:** Perform checks on the `ETHLiquidity` balance as a preventive monitoring measure. User-filed support tickets may flag this issue in case of failure.
-- **Recovery Path(s):** Coordinate an L2 hard fork to replenish the `ETHLiquidity` contract. Investigate the causes of the depletion to determine if other factors are involved.
+- **Recovery Path(s):** Coordinate an L2 hard fork to replenish the `ETHLiquidity` contract. Investigate the causes of the depletion to determine if other factors are involved. Messages will need to be retried for relaying; otherwise, use the `expireMessage` feature if it is available and integrated into `SuperchainWETH`.
 
 ### FM2: Overflow during `burn` in `ETHLiquidity` due to max Balance
 

--- a/security/fma-superchainweth.md
+++ b/security/fma-superchainweth.md
@@ -3,8 +3,8 @@
 | Author | Joxes, Gotzen, Parti |
 | --- | --- |
 | Created at | 2025-01-10 |
-| Initial Reviewers | Pending |
-| Needs Approval From | Pending |
+| Initial Reviewers | Kelvin Fichter, Michael Amadi |
+| Needs Approval From | Kelvin Fichter |
 | Status | In Review |
 
 ## Introduction

--- a/security/fma-superchainweth.md
+++ b/security/fma-superchainweth.md
@@ -9,11 +9,11 @@
 
 ## Introduction
 
-This document covers the addition of SuperchainWETH, an interop-enabled version of the WETH contract that allows ETH to be moved across a set of interoperable chains. SuperchainWETH is an ERC20 contract compliant with the ERC-7802 standard and complies with the same address property. The following components are included:
+This document covers the addition of SuperchainWETH, an interop-enabled version of the WETH contract that allows ETH to be moved across a set of interoperable chains. It act as a wrapper contract compliant with the SuperchainERC20 standard and also have built-in bridging logic. The following components are included:
 
 - **Contracts**:
-    - Introduction of the `SuperchainWETH` predeploy proxy and implementation contract. It allows to wrapping ETH into SuperchainWETH and contains the logic to allow direct ETH interop transfers ETH.
-    - Introduction of the `ETHLiquidity` predeploy proxy and implementation contract, designed to ensure the conversion of SuperchainWETH into native ETH when the supply increases upon calling `crosschainMint`, by maintaining a large reserve of native ETH.
+    - Introducing the `SuperchainWETH` predeploy proxy and implementation contract. It enables wrapping ETH into SuperchainWETH and includes logic for direct ETH interop transfers.
+    - Introducing the `ETHLiquidity` predeploy proxy and implementation contract. It is designed to facilitate the conversion of SuperchainWETH into native ETH—triggered when the supply increases through `crosschainMint` via `relayERC20`—by maintaining a large reserve of native ETH.
 
 Below are references for this project:
 
@@ -35,55 +35,25 @@ Below are references for this project:
 
 ## Failure Modes and Recovery Paths
 
-### FM1: Can call `sendETH` in a Custom Gas Token chain due to `isCustomGasToken`  returning `false`
+### FM1: Insufficient ETH in `ETHLiquidity`
 
-- **Description:** The `sendETH` function requires `IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isCustomGasToken()` to return `true` for chains where a custom gas token is used. If this check is improperly implemented, returning `false`, the system might incorrectly allow `sendETH` calls on chains using a custom gas token.
-- **Risk Assessment:** High.
-    - Potential Impact: High. If the call succeeds on a chain that uses a custom gas token version, it could allow for the possibility of minting native ETH at the destination. There would be economic reasons to do so if the issue is found to be exploitable.
-    - Likelihood: Low. The checker logic is simple enough and `L1Block` exposes this value at every moment, but misconfigurations may occur.
-- **Mitigations:** Ensure `sendETH` checks are implemented correctly and ensure `isCustomGasToken` in L1Block is correctly configured after initialization. The sequencer in the destination chain should not validate any `relayETH` that comes from a `sendETH` call originating in a custom gas token chain.
-- **Detection:** Off-chain monitoring scripts should flag `SendETH` events from custom gas token chains. The `op-supervisor` should detect such a situation within the invariants checks.
-- **Recovery Path(s):** Coordinate an L2 hard fork to revert the subsequent states derived from the failure, and upgrade the predeploy contracts to patch the issue. Pause the system via `SuperchainConfig` if a withdrawal is at risk to finalize. Notify service providers that may be impacted by this failure such as bridges, oracles, and exchanges.
-
-### FM2: Can not call `sendETH` or `crosschainMint` in native ETH chains due to `isCustomGasToken` returning `true`
-
-- **Description:** The `sendETH` and `crosschainMint` function requires `IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isCustomGasToken()` to return `false` for chains where ETH is the native token. If this check is improperly implemented, returning `true`, the system might incorrectly deny `sendETH` or `crosschainMint` calls on chains using ETH as native asset.
-- **Risk Assessment:** Medium.
-    - Potential Impact: Medium. If the call revert, it would deny to send ETH and SuperchainWETH to other chains.
-    - Likelihood: Low. The checker logic is simple enough and `L1Block` exposes this value at every moment, but misconfigurations may occur.
-- **Mitigations:** Ensure `isCustomGasToken` in L1Block is correctly configured after initialization.
-- **Detection:** Off-chain monitoring scripts should flag `SendETH` and `crosschainMint` events that reverts with custom error `isCustomGasToken` on chains that should be ETH native.
-- **Recovery Path(s):** Upgrade `L1Block` contracts to properly configure `isCustomGasToken`.
-
-### FM3: Can call `deposit` or `withdraw` in a Custom Gas Token chain due to `isCustomGasToken` returning `false`
-
-- **Description:** The `deposit` and `withdraw` functions require `IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isCustomGasToken()` to return `true` for chains where a custom gas token is used. If this check is improperly implemented, returning `false`, the system might incorrectly allow to obtain SuperchainWETH.
-- **Risk Assessment:** High.
-    - Potential Impact: High. If the `deposit` call succeeds on a chain that uses a custom gas token version, it could allow for the possibility of minting SuperchainWETH using a custom gas token. There would be economic reasons to do so if the issue is found to be exploitable. The `withdraw` function is less susceptible since it requires storing native liquidity beforehand, and the custom gas token must be more valuable than SuperchainWETH. This would discourage certain types of economic attacks.
-    - Likelihood: Low. The checker logic is simple enough and `L1Block` exposes this value at every moment, but misconfigurations may occur.
-- **Mitigations:** Ensure `deposit` and `withdraw` checks are implemented correctly and `isCustomGasToken` in L1Block is correctly configured after initialization.
-- **Detection:** Off-chain monitoring scripts should flag `Deposit` and `Withdrawal` events from custom gas token chains.
-- **Recovery Path(s):** Coordinate an L2 hard fork to revert the subsequent states derived from the failure, and upgrade the predeploy contracts to patch the issue. Pause the system via `SuperchainConfig` if a withdrawal is at risk to finalize. Notify service providers that may be impacted by this failure such as bridges, oracles, and exchanges.
-
-### FM4: Can not call `deposit` or `withdraw` in native ETH chains due to `isCustomGasToken` returning `true`
-
-- **Description:** The `deposit` and `withdraw` function requires `IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isCustomGasToken()` to return `false` for chains where ETH is the native token. If this check is improperly implemented, returning `true`, the system might incorrectly deny `deposit` or `withdraw` calls between native ETH and SuperchainWETH.
-- **Risk Assessment:** Medium.
-    - Potential Impact: Medium. If any of those calls revert, it would deny to convert between native ETH and SuperchainWETH.
-    - Likelihood: Low. The checker logic is simple enough and `L1Block` exposes this value at every moment, but misconfigurations may occur.
-- **Mitigations:** Ensure `isCustomGasToken` in L1Block is correctly configured after initialization.
-- **Detection:** Off-chain monitoring scripts should flag `Deposit` and `Withdraw` events that revert with custom error `isCustomGasToken` on chains that should be ETH native.
-- **Recovery Path(s):** Upgrade `L1Block` contracts to properly configure `isCustomGasToken`.
-
-### FM5: Insufficient ETH in `ETHLiquidity`
-
-- **Description:** If `ETHLiquidity` lacks sufficient ETH, `mint` calls will revert when the contract attempts to forward funds using `SafeSend`. This breaks bridging flows dependent on `relayETH`  and `crosschainMint`.
-- **Risk Assessment:** Medium.
-    - Potential Impact: Medium. Not having enough ETH balance in `ETHLiquidity` prevents relaying ETH or cross minting SuperchainWETH, which would degrade the user experience.
+- **Description:** If `ETHLiquidity` lacks sufficient ETH, mint calls will revert when the contract attempts to forward funds using `SafeSend`. This breaks bridging flows dependent on `relayETH`  and `crosschainMint`.
+- **Risk Assessment:** Low.
+    - Potential Impact: Medium. Not having enough ETH balance in `ETHLiquidity` prevents relaying ETH or mint SuperchainWETH through `crosschainMint`, which would degrade the user experience.
     - Likelihood: Very low. `ETHLiquidity` starts with a maximum balance (`type(uint248).max`).
-- **Mitigations:** Ensure initial ETH supply in `ETHLiquidity` is `type(uint248).max` after initial config.
-- **Detection:** Existing off-chain scripts should detect if multiple `mint` calls revert. Additionally, check the current `ETHLiquidity` balance. Ensure that the lack of ETH is not due to other failures detailed in this document.
+- **Mitigations:** Our current codebase includes tests to check if the `mint` request exceeds the contract’s balance ([test](https://github.com/ethereum-optimism/optimism/blob/dd37e6192c37ed4c5b18df0269f065f378c495cc/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol#L103)). Initial ETH supply in `ETHLiquidity` is `type(uint248).max` ([test](https://github.com/ethereum-optimism/optimism/blob/dd37e6192c37ed4c5b18df0269f065f378c495cc/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol#L29)) and equally set in all chains.
+- **Detection:** Ideally, off-chain scripts should detect if multiple `mint` calls revert. Additionally, check the current `ETHLiquidity` balance. If that’s not feasible, user-filed support tickets may flag this issue, since funds are not at risk of loss due to this failure.
 - **Recovery Path(s):** Coordinate an L2 hard fork to replenish the `ETHLiquidity` contract. Investigate the causes of the depletion to determine if other factors are involved.
+
+### FM2: Overflow during `burn` in `ETHLiquidity` due to max Balance
+
+- **Description:** If the `ETHLiquidity` contract has already reached the maximum allowed ETH balance (`type(uint256).max`), invoking the `sendETH` function (which triggers `crosschainBurn`) could cause an overflow. This occurs when `burn` is called with an amount that, when added to the current balance, exceeds the maximum `uint256` value. Such an overflow would cause a revert, since the proper Solidity version is used.
+- **Risk Assessment:** Low.
+    - Potential Impact: Medium. Reverts during `sendETH` calls are expected when the requested amount exceeds the maximum value representable by a `uint256`.
+    - Likelihood: Very low. `ETHLiquidity` starts with a maximum balance (`type(uint248).max`) which is still far from `uint256` limit.
+- **Mitigations:** Initial ETH supply in `ETHLiquidity` is `type(uint248).max` properly is checked ([test](https://github.com/ethereum-optimism/optimism/blob/dd37e6192c37ed4c5b18df0269f065f378c495cc/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol#L29)).
+- **Detection:** Given the unlikely nature and potential impact of this case, user-filed support tickets should be sufficient to flag this issue since funds are not at risk of loss due to this failure.
+- **Recovery Path(s):** Coordinate an L2 hard fork to adjust the `ETHLiquidity` contract’s state. Investigate the causes of this failure to determine if other factors are involved.
 
 ### Generic items we need to take into account:
 
@@ -98,9 +68,8 @@ See [relevant FMAs to SuperchainWETH, To Do]
 ## Action Items
 
 - [ ]  Resolve all the comments.
-- [ ]  Proceed with the code implementation and make any necessary approved changes.
-- [ ]  Move into testing of all the components.
-- [ ]  Make sure there are monitoring solutions ready to cover all the cases.
+- [ ]  FM1: Decide whether to use off-chain scripts or rely on a user-support system for detection.
+- [ ]  Ensure the support team is aware of these failure modes and prepared to respond.
 - [ ]  **Ensure that the actions items specified in each FMAs on which SuperchainWETH depends are completed.**
 
 ## Audit Requirements


### PR DESCRIPTION
**Description**

This PR introduces the FMA for the SuperchainWETH design.

**Additional context**

Below are the references for this project:

- Design docs: [intro](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/interoperable-ether.md), [transfer feature](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/interoperable-ether-transfers.md).
- [Specs](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/superchain-weth.md).
- Implementation: [SuperchainWETH](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/superchain-weth.md), [ETHLiquidity](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/ETHLiquidity.sol).

Note that failures upon which SuperchainWETH depends will be covered in a separate document.