### PR TITLE
Fix broken comment syntax

### DIFF
--- a/assets/design-doc-template.md
+++ b/assets/design-doc-template.md
@@ -51,7 +51,7 @@ Does it consume a large amount of computational resources or time? -->
 
 ## Impact on Developer Experience
 <!-- Does this proposed design change the way application developers interact with the protocol?
-Will any Superchain developer tools (like Supersim, templates, etc.) break as a result of this change? ---!>
+Will any Superchain developer tools (like Supersim, templates, etc.) break as a result of this change? -->
 
 ## Alternatives Considered
 


### PR DESCRIPTION
Fixes a syntax error in an html comment closing tag that causes the next markdown section to be considered part of the comment.