### PR TITLE
FMA for Cannon updates for Go 1.23 and Kona

### DIFF
--- a/security/fma-cannon-updates-for-go-1.23-and-kona.md
+++ b/security/fma-cannon-updates-for-go-1.23-and-kona.md
@@ -24,7 +24,7 @@ _Italics are used to indicate things that need to be replaced._
 | Created at         | 2025-05-02                                         |
 | Initial Reviewers  | Meredith Baxter                                    |  
 | Need Approval From | Matt Solomon                                       |  
-| Status             | Implementing Actions                               |  
+| Status             | Final                                              |  
 
 > [!NOTE]
 > 📢 Remember:


### PR DESCRIPTION
Adds an FMA for Cannon updates for Go 1.23 and Kona.

Closes https://github.com/ethereum-optimism/release-management/issues/323