### PR TITLE
update minimum base fee design doc

### DIFF
--- a/protocol/minimum-base-fee.md
+++ b/protocol/minimum-base-fee.md
@@ -47,7 +47,7 @@ Additionally,
 - there is no additional data beyond these 10 bytes
 
 Note that `extraData` has a maximum capacity of 32 bytes (to fit in the L1 beacon-chain `extraData` data-type) and its
-format may be modified/extended by future upgrades.
+format may be modified/extended by future upgrades. Furthermore, when decoding `extraData`, it makes a best-effort for every block in the chain's history, including before the minimum base fee was enabled.
 
 ## Minimum Base Fee in `PayloadAttributesV3`
 
@@ -64,7 +64,7 @@ PayloadAttributesV3: {
     transactions: array of DATA
     noTxPool: bool
     gasLimit: QUANTITY or null
-    eip1559Params: DATA (9 bytes) or null
+    eip1559Params: DATA (8 bytes) or null
 }
 ```
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Updates the minimum base fee design document to include a note about decoding `extraData` and its best-effort for all blocks in the chain's history. For more context see: https://github.com/wlawt/optimism/pull/10#discussion_r2232020344

It also updates the # of bytes for `eip1559Params` back to 8 bytes to maintain cleaner backwards compatibility. For more context see: https://github.com/wlawt/optimism/pull/10#discussion_r2229144428

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

N/A

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

N/A

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

N/A