### PR TITLE
docs: removed dead links

### DIFF
--- a/security/fma-holocene.md
+++ b/security/fma-holocene.md
@@ -179,8 +179,6 @@ Below is what needs to be done before launch to reduce the chances of the above 
     * https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.10.0
     * https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101411.2
     * https://github.com/paradigmxyz/reth/releases/tag/v1.1.2
-    * https://github.com/ethereum-optimism/k8s/pull/5032
-    * https://github.com/ethereum-optimism/k8s/pull/5053
 
 - [x] (BLOCKING): we will re-architect the batcher to eliminate the cases above
     * [Holocene-D: Batcher Hardening](https://github.com/ethereum-optimism/optimism/issues/12120)


### PR DESCRIPTION
**Description**
removed outdated links that returned 404 errors.
these links were no longer valid and have been cleaned up to improve documentation accuracy.

**Tests**
verified that all remaining links are active and return valid responses.
no functional code was affected.

**Additional context**
the removed links were previously found in:

* [https://github.com/ethereum-optimism/k8s/pull/5032](https://github.com/ethereum-optimism/k8s/pull/5032)
* [https://github.com/ethereum-optimism/k8s/pull/5053](https://github.com/ethereum-optimism/k8s/pull/5053)

**Metadata**

* type: doc cleanup
* status: ready for review
