### PR TITLE
docs: Fix broken link to Kona website

### DIFF
--- a/security/fma-kona-asterisc.md
+++ b/security/fma-kona-asterisc.md
@@ -45,7 +45,6 @@ fault proof component. The Failure Modes and Recovery Paths below detail this as
 Below are references for this project:
 
 - ["Stage 1.4" internal project document](https://www.notion.so/oplabs/Stage-1-4-Partway-a6f57ad777b148dda01488f2646cff17)
-- [Kona Documentation](https://anton-rs.github.io/kona/).
 - [Kona Repository](https://github.com/anton-rs/kona).
 - [Asterisc Repository](https://github.com/ethereum-optimism/asterisc)
 


### PR DESCRIPTION
**Description**
I removed the link to [[Kona](https://anton-rs.github.io/kona/)](https://anton-rs.github.io/kona/) since the site no longer exists and was causing a 404 error. This should prevent users from encountering the dead page.


**Tests**
**Additional context**
**Metadata**