### PR TITLE
Add L2 Contract Upgrades design doc

### DIFF
--- a/protocol/l2-contract-upgrades.md
+++ b/protocol/l2-contract-upgrades.md
@@ -74,7 +74,7 @@ The NUT file will be stored in the monorepo, and tracked by git. It will be upda
 
 A given set of upgrade transactions will typically perform the following actions:
 
-1. deploy new `ConditionalDeployer` contract
+1. deploy new `ConditionalDeployer` contract (This step will only be needed the first time this scheme is used)
 2. deploy new implementations via the `ConditionalDeployer`
 2. deploy a new `L2ContractsManager`
 3. update the `ProxyAdmin` (This step will only be needed the first time this scheme is used)


### PR DESCRIPTION
## Purpose

To enable deterministic, well tested, hard fork driven upgrades of L2 contracts, with both the implementation and upgrade path written in Solidity.

The customers for this work include:

- protocol devs seeking to modify L2 contracts
- chain operators looking for improvements
- anyone who has ever worried about unclear and inconsistent versioning of L2 contracts across OP chains

## Summary

The proposed design maintains the current method of injecting Network Upgrade Transactions (NUTs) at a specific fork block height, while improving on the development and testing process in order to better enable safe, well-tested, multi-client upgrades of L2 contracts.

This is achieved by putting the transaction data into a JSON file, and then executing it at the specified fork block.

The design aims to create a solution which parallels the OPCM, but for L2.