### PR TITLE
feat(pcd): Add Predictive Chain Deployments design doc

### DIFF
--- a/ecosystem/op-deployer/predictive-chain-deployments/fma.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/fma.md
@@ -8,9 +8,8 @@
   - [FM1: L1 Anchor Reorg](#fm1-l1-anchor-reorg)
   - [FM2: Predicted ≠ Deployed L1 Addresses](#fm2-predicted-%E2%89%A0-deployed-l1-addresses)
   - [FM3: Compromised L1 RPC](#fm3-compromised-l1-rpc)
-  - [FM4: Build Service Returns Wrong Prestate Hash](#fm4-build-service-returns-wrong-prestate-hash)
-  - [FM5: Build Service Unavailability](#fm5-build-service-unavailability)
-  - [FM6: Genesis Timestamp Overrun](#fm6-genesis-timestamp-overrun)
+  - [FM4: Wrong Prestate Hash](#fm4-wrong-prestate-hash)
+  - [FM5: Genesis Timestamp Overrun](#fm5-genesis-timestamp-overrun)
 - [Audit Requirements](#audit-requirements)
 - [Appendix](#appendix)
   - [Appendix A: CREATE2 Address Prediction](#appendix-a-create2-address-prediction)
@@ -29,7 +28,7 @@
 
 The Predictive Chain Deployments feature reorders `op-deployer`'s pipeline to compute `startingAnchorRoot` and `absolutePrestate` off-chain before calling `OPCM.deploy()`. This enables the permissionless dispute game from L2 block 0.
 
-The pipeline introduces two new external dependencies on the critical path before any transaction lands on L1: the L1 RPC (for the `eth_call` dry-run) and the hosted prestate build service. The failure modes below cover where those dependencies and the new sequencing can go wrong.
+The pipeline introduces one new external dependency on the critical path before any transaction lands on L1: the L1 RPC, for the `eth_call` dry-run. The failure modes below cover where that step, the L1 RPC, and the new sequencing can go wrong.
 
 References:
 
@@ -67,26 +66,17 @@ References:
 - **Detection:** Post-deploy validation compares every address the dry-run returned against what `OPCM.deploy()` actually emitted. A fabricated address produces an immediate mismatch.
 - **Recovery Path(s):** Full redeployment against a trusted RPC.
 
-### FM4: Build Service Returns Wrong Prestate Hash
+### FM4: Wrong Prestate Hash
 
-- **Description:** The hosted build service returns an incorrect prestate hash without signaling an error. The deployed dispute game carries the wrong `absolutePrestate` (the agreed starting MIPS machine state for fault proof disputes). Fault proofs fail silently from genesis.
+- **Description:** The prestate hash written to the state is incorrect, either miscomputed by the `prestate` command or a bad override resolved from the intent. The deployed dispute game carries the wrong `absolutePrestate` (the agreed starting MIPS machine state for fault proof disputes). Fault proofs fail silently from genesis.
 - **Risk Assessment:** Low likelihood, high impact. The fault proof system is broken from block 0 with no on-chain guard to catch it at deploy time.
 - **Mitigations:**
-  1. Use a trusted build service endpoint.
-  2. Before submitting `OPCM.deploy()`, reproduce the prestate build locally and compare the returned hash against the local result.
-- **Detection:** After deployment, replay the prestate build locally using the same `genesis.json`, `rollup.json`, and `depsets.json` that were submitted to the build service. Compare the result against the `absolutePrestate` written into the deployed dispute game contract. A mismatch confirms the build service returned a wrong value.
-- **Recovery Path(s):** Full redeployment with the correct prestate hash sourced from a verified local build.
+  1. Source any override from a trusted, reproducible build.
+  2. Before running `continue`, reproduce the prestate build and compare the result against the value in the state.
+- **Detection:** Replay the prestate build using the same `genesis.json`, `rollup.json`, and `depsets.json` from `prepare`, and compare the result against the `absolutePrestate` in the state, and after deployment against the value written into the deployed dispute game contract. A mismatch confirms a wrong hash.
+- **Recovery Path(s):** Full redeployment with the correct prestate hash sourced from a verified build.
 
-### FM5: Build Service Unavailability
-
-- **Description:** The hosted build service is unreachable. The prestate build step cannot complete, blocking deployment.
-- **Risk Assessment:** Medium likelihood (external dependency), medium impact. Deployment is blocked; no deployed chain is harmed.
-- **Mitigations:**
-  1. Configure the build service URL to point to an alternative endpoint.
-- **Detection:** The prestate build step returns a connection error. `op-deployer` exits with a failure message identifying the step.
-- **Recovery Path(s):** Retry once the build service is available. Each pipeline step checks whether its output already exists in state before running, so a retry resumes from the failed step without re-executing earlier stages.
-
-### FM6: Genesis Timestamp Overrun
+### FM5: Genesis Timestamp Overrun
 
 - **Description:** Steps 3–8 take longer than `X` (the configured offset between the anchor timestamp and `genesis_time`). `genesis_time` is already in the past when `OPCM.deploy()` mines. The deployment succeeds with no on-chain guard catching the overrun. `op-node` fills the elapsed gap with empty L2 blocks before user transactions can land.
 - **Risk Assessment:** Low likelihood, low impact. A 10-minute overrun produces ~300 empty blocks at the default 2-second `L2BlockTime`. The chain operates correctly; no state is corrupted.

--- a/ecosystem/op-deployer/predictive-chain-deployments/fma.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/fma.md
@@ -10,6 +10,7 @@
   - [FM3: Compromised L1 RPC](#fm3-compromised-l1-rpc)
   - [FM4: Wrong Prestate Hash](#fm4-wrong-prestate-hash)
   - [FM5: Genesis Timestamp Overrun](#fm5-genesis-timestamp-overrun)
+  - [FM6: Stale Prestate After Re-run of `prepare`](#fm6-stale-prestate-after-re-run-of-prepare)
 - [Audit Requirements](#audit-requirements)
 - [Appendix](#appendix)
   - [Appendix A: CREATE2 Address Prediction](#appendix-a-create2-address-prediction)
@@ -85,6 +86,16 @@ References:
   2. Operators on slower hardware should raise `X` via the override flag before deploying.
 - **Detection:** `op-node` logs indicate it is behind and filling gap blocks. The gap size is `(mining_time - genesis_time) / L2BlockTime` blocks.
 - **Recovery Path(s):** No action required if the empty-block gap is acceptable. For deployments where the gap is unacceptable, redeploy with a larger `X`.
+
+### FM6: Stale Prestate After Re-run of `prepare`
+
+- **Description:** `prepare` is re-run, for example to recover a stuck deployment or after a reorg, and re-picks a fresh anchor. That produces a new `genesis_time` and therefore new `genesis.json` and `rollup.json`. If a prestate built against the previous `genesis_time` is reused instead of rebuilt, the deployed `absolutePrestate` does not match the committed `rollup.json`. Fault proofs are broken from genesis.
+- **Risk Assessment:** Low likelihood, high impact. Requires `prepare` to be re-run with a new `genesis_time` while a prestate from the prior run is still present. Impact is high as fault proofs are broken from block 0.
+- **Mitigations:**
+  1. Re-running `prepare` with a fresh anchor invalidates the prestate in the state, forcing a rebuild before `continue` proceeds.
+  2. The prestate is built from the committed `rollup.json`, so rebuilding after any `genesis_time` change keeps the prestate and the deployed artifacts consistent.
+- **Detection:** Reproduce the prestate from the current committed `genesis.json`, `rollup.json`, and `depsets.json` and compare against the `absolutePrestate` in the state. A mismatch means the prestate is stale relative to the current artifacts.
+- **Recovery Path(s):** Rebuild the prestate from the current artifacts and re-commit the hash before running `continue`.
 
 ## Audit Requirements
 

--- a/ecosystem/op-deployer/predictive-chain-deployments/fma.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/fma.md
@@ -18,8 +18,8 @@
 
 |                    |                                    |
 | ------------------ | ---------------------------------- |
-| Author             | _Author Name_                      |
-| Created at         | _YYYY-MM-DD_                       |
+| Author             | Joxess, 0xOneTony, 0xiamflux       |
+| Created at         | _2026-05-26_                       |
 | Initial Reviewers  | _Reviewer Name 1, Reviewer Name 2_ |
 | Need Approval From | _Security Reviewer Name_           |
 | Status             | _Draft_                            |

--- a/ecosystem/op-deployer/predictive-chain-deployments/fma.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/fma.md
@@ -11,6 +11,7 @@
   - [FM4: Wrong Prestate Hash](#fm4-wrong-prestate-hash)
   - [FM5: Genesis Timestamp Overrun](#fm5-genesis-timestamp-overrun)
   - [FM6: Stale Prestate After Re-run of `prepare`](#fm6-stale-prestate-after-re-run-of-prepare)
+  - [FM7: Wrong startingAnchorRoot](#fm7-wrong-startinganchorroot)
 - [Audit Requirements](#audit-requirements)
 - [Appendix](#appendix)
   - [Appendix A: CREATE2 Address Prediction](#appendix-a-create2-address-prediction)
@@ -97,6 +98,17 @@ References:
   2. The prestate is built from the committed `rollup.json`, so rebuilding after any `genesis_time` change keeps the prestate and the deployed artifacts consistent.
 - **Detection:** Reproduce the prestate from the current committed `genesis.json`, `rollup.json`, and `depsets.json` and compare against the `absolutePrestate` in the state. A mismatch means the prestate is stale relative to the current artifacts.
 - **Recovery Path(s):** Rebuild the prestate from the current artifacts and re-commit the hash before running `continue`.
+
+### FM7: Wrong startingAnchorRoot
+
+- **Description:** The `startingAnchorRoot` committed to the state is incorrect. `OPCM.deploy()` seeds `AnchorStateRegistry` with this anchor, and every dispute game bootstraps its proof from it. Because the anchor does not match the real genesis, the program is told to start from a state that never existed, so honest proposals that descend from the real genesis cannot be proven and fault proofs are broken from block 0.
+- **Risk Assessment:** Low likelihood, high impact. The output root is computed deterministically from the genesis block in the `op-deployer` pipeline which makes the most probable causes are either a derivation bug or a wrong value written in state files.
+- **Mitigations:**
+  1. Before running `continue`, the reviewer should recompute `outputRoot = keccak256(version || stateRoot || messagePasserStorageRoot || blockHash)` from the committed genesis block and compare against the `startingAnchorRoot` in the state.
+- **Detection:** Recompute the `startingAnchorRoot` from the same values the pipeline computes it from. Post-deploy validation reads the anchor from `AnchorStateRegistry.getStartingAnchorRoot()` and compares it against recomputed anchor root for the genesis block. A mismatch confirms a wrong anchor root.
+- **Recovery Path(s):** Depends on where in the pipeline the bad anchor is caught:
+  1. **Before `OPCM.deploy()`.** A reviewer recomputing the `startingAnchorRoot` flags the mismatch while the anchor still lives only in the configuration artifacts. Fix the value and continue the pipeline.
+  2. **During post-deploy validation** Full redeployment is required with the correct anchor root.
 
 ## Audit Requirements
 

--- a/ecosystem/op-deployer/predictive-chain-deployments/fma.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/fma.md
@@ -53,9 +53,10 @@ References:
 - **Risk Assessment:** Low likelihood, high impact. CREATE2 is deterministic given the same `msg.sender` and `saltMixer`. The most likely cause is a dry-run sent from a different address than the real broadcast.
 - **Mitigations:**
   1. The `eth_call` dry-run must use the same `from` address as the real `OPCM.deploy()` broadcast.
-  2. Post-deploy validation compares predicted vs. deployed addresses.
-- **Detection:** Post-deploy validation catches any mismatch immediately after deployment.
-- **Recovery Path(s):** Full redeployment using the correct sender address.
+  2. A pre-broadcast preflight in `continue` re-checks the predicted addresses against current L1 state before the actual deployment.
+  3. Post-deploy validation compares predicted vs. deployed addresses.
+- **Detection:** The pre-broadcast preflight in `continue` re-runs the dry-run and aborts before the deploy if the predicted addresses no longer match the committed genesis. Post-deploy validation is the backstop.
+- **Recovery Path(s):** If the preflight catches the mismatch, fix the sender address and re-run `continue`; nothing was deployed. If it is caught only post-deploy, full redeployment with the correct sender address is required.
 
 ### FM3: Compromised L1 RPC
 

--- a/ecosystem/op-deployer/predictive-chain-deployments/fma.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/fma.md
@@ -65,7 +65,8 @@ References:
 - **Risk Assessment:** Low likelihood, high impact. The chain is unusable if the fabricated addresses differ from what OPCM actually deploys.
 - **Mitigations:**
   1. Use a trusted or self-hosted L1 RPC endpoint.
-  2. Post-deploy validation is the backstop for this failure mode.
+  2. `op-deployer` cross-checks the dry-run against a second, independent L1 RPC. Different addresses flag a compromised endpoint before deployment.
+  3. Post-deploy validation is the backstop for this failure mode.
 - **Detection:** Post-deploy validation compares every address the dry-run returned against what `OPCM.deploy()` actually emitted. A fabricated address produces an immediate mismatch.
 - **Recovery Path(s):** Full redeployment against a trusted RPC.
 

--- a/ecosystem/op-deployer/predictive-chain-deployments/fma.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/fma.md
@@ -1,0 +1,92 @@
+# Breaking the Cyclic Dependency: Failure Modes and Recovery Path Analysis
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Failure Modes and Recovery Paths](#failure-modes-and-recovery-paths)
+  - [FM1: L1 Anchor Reorg](#fm1-l1-anchor-reorg)
+  - [FM2: Predicted ≠ Deployed L1 Addresses](#fm2-predicted-%E2%89%A0-deployed-l1-addresses)
+  - [FM3: Compromised L1 RPC](#fm3-compromised-l1-rpc)
+  - [FM4: Build Service Bad Behavior](#fm4-build-service-bad-behavior)
+  - [FM5: Build Service Unavailability](#fm5-build-service-unavailability)
+- [Audit Requirements](#audit-requirements)
+- [Appendix](#appendix)
+  - [Appendix A: CREATE2 Address Prediction](#appendix-a-create2-address-prediction)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+|                    |                                    |
+| ------------------ | ---------------------------------- |
+| Author             | _Author Name_                      |
+| Created at         | _YYYY-MM-DD_                       |
+| Initial Reviewers  | _Reviewer Name 1, Reviewer Name 2_ |
+| Need Approval From | _Security Reviewer Name_           |
+| Status             | _Draft_                            |
+
+## Introduction
+
+This document covers the failure modes for the Predictive Chain Deployments feature in `op-deployer`. The feature reorders the deployment pipeline to compute `startingAnchorRoot` and `absolutePrestate` off-chain before calling `OPCM.deploy()`, enabling the permissionless dispute game to be active from L2 block 0.
+
+References:
+
+- [design.md](./pcd-design.md)
+
+## Failure Modes and Recovery Paths
+
+### FM1: L1 Anchor Reorg
+
+- **Description:** If Ethereum reorgs past the anchor block after `op-deployer` picks it, the chain will be unable to start. The anchor's hash is baked into `rollup.json` and the prestate, so a reorg invalidates both.
+- **Risk Assessment:** Low likelihood (anchor is picked at the `safe` tag, which requires one epoch ~6 minutes to finalize), high impact (requires full redeployment).
+- **Mitigations:**
+  1. Only `safe`-tag blocks or deeper are eligible as the anchor block.
+  2. A `BLOCKHASH` opcode check in the deploy transaction can cause it to revert if the anchor block has been reorged out.
+- **Detection:** Post-deploy validation confirms deployed L1 addresses match predicted addresses; a mismatch indicates the anchor was invalid.
+- **Recovery Path(s):** If the reorg occurs before `OPCM.deploy()`, abort the run and restart with a new anchor block. If `OPCM.deploy()` has already been mined with an invalid anchor, full redeployment is required.
+
+### FM2: Predicted ≠ Deployed L1 Addresses
+
+- **Description:** Mismatch between `eth_call` dry-run and real `OPCM.deploy()` emissions. The L2 genesis was built against the predicted addresses, making the deployed chain unsafe to operate.
+- **Risk Assessment:** Low likelihood (CREATE2 is deterministic given same `msg.sender` and salt), high impact (chain is unusable).
+- **Mitigations:**
+  1. The `eth_call` dry-run must be sent `from` the same address that broadcasts the real `OPCM.deploy()`.
+  2. Post-deploy validation compares predicted vs. deployed addresses.
+- **Detection:** Post-deploy validation will catch any mismatch immediately after deployment.
+- **Recovery Path(s):** Full redeployment with the correct sender address.
+
+### FM3: Compromised L1 RPC
+
+- **Description:** A compromised L1 RPC endpoint might return false chain contracts in response to the `eth_call` dry-run, causing the genesis to be built against incorrect predicted addresses.
+- **Risk Assessment:** Low likelihood, high impact (chain is unusable; may not be detected until post-deploy validation).
+- **Mitigations:**
+  1. Operators should use trusted or self-hosted L1 RPC endpoints.
+  2. Post-deploy validation will surface the mismatch.
+- **Detection:** Post-deploy validation (Step 10).
+- **Recovery Path(s):** Full redeployment against a trusted RPC.
+
+### FM4: Build Service Bad Behavior
+
+- **Description:** The hosted build service returns an incorrect prestate hash as a silent failure, causing `absolutePrestate` in the deployed dispute game to be wrong. Fault proofs would fail silently.
+- **Risk Assessment:** Low likelihood, high impact (fault proof system is broken from genesis).
+- **Mitigations:**
+  1. Operators should use a trusted build service endpoint.
+  2. Independently verify the prestate hash against a local build.
+- **Detection:** Fault proof disputes will fail to resolve correctly. No automated detection is defined in this milestone.
+- **Recovery Path(s):** Requires redeployment with the correct prestate hash.
+
+### FM5: Build Service Unavailability
+
+- **Description:** The hosted build service is unreachable. Step 8 cannot be completed, blocking the full permissionless deployment path.
+- **Risk Assessment:** Medium likelihood (external dependency), medium impact (deployment is blocked but no chain is harmed).
+- **Mitigations:**
+  1. Operators can configure `--op-program-svc-url` to point to an alternative endpoint.
+- **Detection:** Step 8 returns an error; `op-deployer` exits with a failure message.
+- **Recovery Path(s):** Retry once the build service is available. The pipeline's `should`\* idempotency pattern allows safe retry from the failed step.
+
+## Audit Requirements
+
+## Appendix
+
+### Appendix A: CREATE2 Address Prediction
+
+The `eth_call` dry-run of `OPCM.deploy()` works because OPCM proxy deployments use CREATE2 with a salt that mixes in `msg.sender` and a `saltMixer` string from `FullConfig`. Given identical inputs (same sender, same config, same L1 state), the EVM deterministically produces the same addresses without writing to state. The dry-run must therefore use the same `from` address as the real broadcast, or the predicted addresses will differ.

--- a/ecosystem/op-deployer/predictive-chain-deployments/fma.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/fma.md
@@ -74,7 +74,7 @@ References:
 - **Risk Assessment:** Low likelihood, high impact. The fault proof system is broken from block 0 with no on-chain guard to catch it at deploy time.
 - **Mitigations:**
   1. Source any override from a trusted, reproducible build.
-  2. Before running `continue`, reproduce the prestate build and compare the result against the value in the state.
+  2. Before running `continue`, the reviewer should reproduce the prestate build locally, and compare the result against the value in the state.
 - **Detection:** Replay the prestate build using the same `genesis.json`, `rollup.json`, and `depsets.json` from `prepare`. Compare the result against the `absolutePrestate` in the state, and after deployment against the value in the deployed dispute game contract. A mismatch confirms a wrong hash.
 - **Recovery Path(s):** Full redeployment with the correct prestate hash sourced from a verified build.
 

--- a/ecosystem/op-deployer/predictive-chain-deployments/fma.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/fma.md
@@ -26,13 +26,13 @@
 
 ## Introduction
 
-The Predictive Chain Deployments feature reorders `op-deployer`'s pipeline to compute `startingAnchorRoot` and `absolutePrestate` off-chain before calling `OPCM.deploy()`. This enables the permissionless dispute game from L2 block 0.
+The Predictive Chain Deployments feature reorders `op-deployer`'s pipeline to compute two values off-chain before calling `OPCM.deploy()`: the `startingAnchorRoot` (the dispute system's starting anchor) and the `absolutePrestate` (the fault proof's agreed starting state). This makes the permissionless dispute game valid from L2 block 0.
 
-The pipeline introduces one new external dependency on the critical path before any transaction lands on L1: the L1 RPC, for the `eth_call` dry-run. The failure modes below cover where that step, the L1 RPC, and the new sequencing can go wrong.
+The new risk comes from deriving those values off-chain. One external dependency now sits on the critical path before any transaction lands on L1: the L1 RPC, used for the `eth_call` dry-run. The failure modes below cover that dependency and the new sequencing.
 
 References:
 
-- [design.md](./pcd-design.md)
+- [PCD design](./pcd-design.md)
 
 ## Failure Modes and Recovery Paths
 
@@ -73,13 +73,13 @@ References:
 - **Mitigations:**
   1. Source any override from a trusted, reproducible build.
   2. Before running `continue`, reproduce the prestate build and compare the result against the value in the state.
-- **Detection:** Replay the prestate build using the same `genesis.json`, `rollup.json`, and `depsets.json` from `prepare`, and compare the result against the `absolutePrestate` in the state, and after deployment against the value written into the deployed dispute game contract. A mismatch confirms a wrong hash.
+- **Detection:** Replay the prestate build using the same `genesis.json`, `rollup.json`, and `depsets.json` from `prepare`. Compare the result against the `absolutePrestate` in the state, and after deployment against the value in the deployed dispute game contract. A mismatch confirms a wrong hash.
 - **Recovery Path(s):** Full redeployment with the correct prestate hash sourced from a verified build.
 
 ### FM5: Genesis Timestamp Overrun
 
 - **Description:** Steps 3–8 take longer than `X` (the configured offset between the anchor timestamp and `genesis_time`). `genesis_time` is already in the past when `OPCM.deploy()` mines. The deployment succeeds with no on-chain guard catching the overrun. `op-node` fills the elapsed gap with empty L2 blocks before user transactions can land.
-- **Risk Assessment:** Low likelihood, low impact. A 10-minute overrun produces ~300 empty blocks at the default 2-second `L2BlockTime`. The chain operates correctly; no state is corrupted.
+- **Risk Assessment:** Low likelihood, low impact. A 10-minute overrun produces ~300 empty blocks at the default 2-second `L2BlockTime`. The chain operates correctly. No state is corrupted.
 - **Mitigations:**
   1. Set `X` conservatively above the typical end-to-end pipeline runtime, including the prestate build.
   2. Operators on slower hardware should raise `X` via the override flag before deploying.

--- a/ecosystem/op-deployer/predictive-chain-deployments/fma.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/fma.md
@@ -70,7 +70,7 @@ References:
 
 ### FM4: Wrong Prestate Hash
 
-- **Description:** The prestate hash written to the state is incorrect, either miscomputed by the `prestate` command or a bad override resolved from the intent. The deployed dispute game carries the wrong `absolutePrestate` (the agreed starting MIPS machine state for fault proof disputes). Fault proofs fail silently from genesis.
+- **Description:** The prestate hash written to the state is incorrect, either a bad hash passed through the command flag or a bad override resolved from the intent. The deployed dispute game carries the wrong `absolutePrestate` (the agreed starting MIPS machine state for fault proof disputes). Fault proofs fail silently from genesis.
 - **Risk Assessment:** Low likelihood, high impact. The fault proof system is broken from block 0 with no on-chain guard to catch it at deploy time.
 - **Mitigations:**
   1. Source any override from a trusted, reproducible build.

--- a/ecosystem/op-deployer/predictive-chain-deployments/fma.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/fma.md
@@ -8,8 +8,9 @@
   - [FM1: L1 Anchor Reorg](#fm1-l1-anchor-reorg)
   - [FM2: Predicted ≠ Deployed L1 Addresses](#fm2-predicted-%E2%89%A0-deployed-l1-addresses)
   - [FM3: Compromised L1 RPC](#fm3-compromised-l1-rpc)
-  - [FM4: Build Service Bad Behavior](#fm4-build-service-bad-behavior)
+  - [FM4: Build Service Returns Wrong Prestate Hash](#fm4-build-service-returns-wrong-prestate-hash)
   - [FM5: Build Service Unavailability](#fm5-build-service-unavailability)
+  - [FM6: Genesis Timestamp Overrun](#fm6-genesis-timestamp-overrun)
 - [Audit Requirements](#audit-requirements)
 - [Appendix](#appendix)
   - [Appendix A: CREATE2 Address Prediction](#appendix-a-create2-address-prediction)
@@ -26,7 +27,9 @@
 
 ## Introduction
 
-This document covers the failure modes for the Predictive Chain Deployments feature in `op-deployer`. The feature reorders the deployment pipeline to compute `startingAnchorRoot` and `absolutePrestate` off-chain before calling `OPCM.deploy()`, enabling the permissionless dispute game to be active from L2 block 0.
+The Predictive Chain Deployments feature reorders `op-deployer`'s pipeline to compute `startingAnchorRoot` and `absolutePrestate` off-chain before calling `OPCM.deploy()`. This enables the permissionless dispute game from L2 block 0.
+
+The pipeline introduces two new external dependencies on the critical path before any transaction lands on L1: the L1 RPC (for the `eth_call` dry-run) and the hosted prestate build service. The failure modes below cover where those dependencies and the new sequencing can go wrong.
 
 References:
 
@@ -36,57 +39,71 @@ References:
 
 ### FM1: L1 Anchor Reorg
 
-- **Description:** If Ethereum reorgs past the anchor block after `op-deployer` picks it, the chain will be unable to start. The anchor's hash is baked into `rollup.json` and the prestate, so a reorg invalidates both.
-- **Risk Assessment:** Low likelihood (anchor is picked at the `safe` tag, which requires one epoch ~6 minutes to finalize), high impact (requires full redeployment).
+- **Description:** Ethereum reorgs past the anchor block after `op-deployer` picks it. The anchor hash is baked into `rollup.json` and the prestate. A reorg invalidates both, leaving the chain unable to start.
+- **Risk Assessment:** Low likelihood, high impact. The anchor is picked at the `safe` tag, which requires one epoch (~6 minutes) to reach. Reorgs past the safe tag are rare on Ethereum mainnet.
 - **Mitigations:**
-  1. Only `safe`-tag blocks or deeper are eligible as the anchor block.
-  2. A `BLOCKHASH` opcode check in the deploy transaction can cause it to revert if the anchor block has been reorged out.
-- **Detection:** Post-deploy validation confirms deployed L1 addresses match predicted addresses; a mismatch indicates the anchor was invalid.
-- **Recovery Path(s):** If the reorg occurs before `OPCM.deploy()`, abort the run and restart with a new anchor block. If `OPCM.deploy()` has already been mined with an invalid anchor, full redeployment is required.
+  1. Only blocks at the `safe` tag or deeper are eligible as the anchor.
+  2. A `BLOCKHASH` opcode check in the deploy transaction reverts if the anchor block no longer exists at deployment time.
+- **Detection:** If the reorg occurs before `OPCM.deploy()`: the `BLOCKHASH` opcode check in the deploy transaction reverts, aborting the deployment. If the reorg occurs after `OPCM.deploy()` mines: `op-node` fails to initialize because the anchor block hash in `rollup.json` no longer exists in the canonical L1 chain.
+- **Recovery Path(s):** If the reorg occurs before `OPCM.deploy()`, abort and restart with a new anchor block. If `OPCM.deploy()` already mined with an invalid anchor, full redeployment is required.
 
 ### FM2: Predicted ≠ Deployed L1 Addresses
 
-- **Description:** Mismatch between `eth_call` dry-run and real `OPCM.deploy()` emissions. The L2 genesis was built against the predicted addresses, making the deployed chain unsafe to operate.
-- **Risk Assessment:** Low likelihood (CREATE2 is deterministic given same `msg.sender` and salt), high impact (chain is unusable).
+- **Description:** The `eth_call` dry-run and the real `OPCM.deploy()` emit different L1 contract addresses. The L2 genesis was built against the predicted addresses, so any mismatch makes the chain unsafe to operate.
+- **Risk Assessment:** Low likelihood, high impact. CREATE2 is deterministic given the same `msg.sender` and `saltMixer`. The most likely cause is a dry-run sent from a different address than the real broadcast.
 - **Mitigations:**
-  1. The `eth_call` dry-run must be sent `from` the same address that broadcasts the real `OPCM.deploy()`.
+  1. The `eth_call` dry-run must use the same `from` address as the real `OPCM.deploy()` broadcast.
   2. Post-deploy validation compares predicted vs. deployed addresses.
-- **Detection:** Post-deploy validation will catch any mismatch immediately after deployment.
-- **Recovery Path(s):** Full redeployment with the correct sender address.
+- **Detection:** Post-deploy validation catches any mismatch immediately after deployment.
+- **Recovery Path(s):** Full redeployment using the correct sender address.
 
 ### FM3: Compromised L1 RPC
 
-- **Description:** A compromised L1 RPC endpoint might return false chain contracts in response to the `eth_call` dry-run, causing the genesis to be built against incorrect predicted addresses.
-- **Risk Assessment:** Low likelihood, high impact (chain is unusable; may not be detected until post-deploy validation).
+- **Description:** A compromised L1 RPC returns fabricated results for the `eth_call` dry-run. The genesis is built against those false addresses. The mismatch surfaces only after `OPCM.deploy()` when post-deploy validation runs.
+- **Risk Assessment:** Low likelihood, high impact. The chain is unusable if the fabricated addresses differ from what OPCM actually deploys.
 - **Mitigations:**
-  1. Operators should use trusted or self-hosted L1 RPC endpoints.
-  2. Post-deploy validation will surface the mismatch.
-- **Detection:** Post-deploy validation (Step 10).
+  1. Use a trusted or self-hosted L1 RPC endpoint.
+  2. Post-deploy validation is the backstop for this failure mode.
+- **Detection:** Post-deploy validation compares every address the dry-run returned against what `OPCM.deploy()` actually emitted. A fabricated address produces an immediate mismatch.
 - **Recovery Path(s):** Full redeployment against a trusted RPC.
 
-### FM4: Build Service Bad Behavior
+### FM4: Build Service Returns Wrong Prestate Hash
 
-- **Description:** The hosted build service returns an incorrect prestate hash as a silent failure, causing `absolutePrestate` in the deployed dispute game to be wrong. Fault proofs would fail silently.
-- **Risk Assessment:** Low likelihood, high impact (fault proof system is broken from genesis).
+- **Description:** The hosted build service returns an incorrect prestate hash without signaling an error. The deployed dispute game carries the wrong `absolutePrestate` (the agreed starting MIPS machine state for fault proof disputes). Fault proofs fail silently from genesis.
+- **Risk Assessment:** Low likelihood, high impact. The fault proof system is broken from block 0 with no on-chain guard to catch it at deploy time.
 - **Mitigations:**
-  1. Operators should use a trusted build service endpoint.
-  2. Independently verify the prestate hash against a local build.
-- **Detection:** Fault proof disputes will fail to resolve correctly. No automated detection is defined in this milestone.
-- **Recovery Path(s):** Requires redeployment with the correct prestate hash.
+  1. Use a trusted build service endpoint.
+  2. Before submitting `OPCM.deploy()`, reproduce the prestate build locally and compare the returned hash against the local result.
+- **Detection:** After deployment, replay the prestate build locally using the same `genesis.json`, `rollup.json`, and `depsets.json` that were submitted to the build service. Compare the result against the `absolutePrestate` written into the deployed dispute game contract. A mismatch confirms the build service returned a wrong value.
+- **Recovery Path(s):** Full redeployment with the correct prestate hash sourced from a verified local build.
 
 ### FM5: Build Service Unavailability
 
-- **Description:** The hosted build service is unreachable. Step 8 cannot be completed, blocking the full permissionless deployment path.
-- **Risk Assessment:** Medium likelihood (external dependency), medium impact (deployment is blocked but no chain is harmed).
+- **Description:** The hosted build service is unreachable. The prestate build step cannot complete, blocking deployment.
+- **Risk Assessment:** Medium likelihood (external dependency), medium impact. Deployment is blocked; no deployed chain is harmed.
 - **Mitigations:**
-  1. Operators can configure `--op-program-svc-url` to point to an alternative endpoint.
-- **Detection:** Step 8 returns an error; `op-deployer` exits with a failure message.
-- **Recovery Path(s):** Retry once the build service is available. The pipeline's `should`\* idempotency pattern allows safe retry from the failed step.
+  1. Configure the build service URL to point to an alternative endpoint.
+- **Detection:** The prestate build step returns a connection error. `op-deployer` exits with a failure message identifying the step.
+- **Recovery Path(s):** Retry once the build service is available. Each pipeline step checks whether its output already exists in state before running, so a retry resumes from the failed step without re-executing earlier stages.
+
+### FM6: Genesis Timestamp Overrun
+
+- **Description:** Steps 3–8 take longer than `X` (the configured offset between the anchor timestamp and `genesis_time`). `genesis_time` is already in the past when `OPCM.deploy()` mines. The deployment succeeds with no on-chain guard catching the overrun. `op-node` fills the elapsed gap with empty L2 blocks before user transactions can land.
+- **Risk Assessment:** Low likelihood, low impact. A 10-minute overrun produces ~300 empty blocks at the default 2-second `L2BlockTime`. The chain operates correctly; no state is corrupted.
+- **Mitigations:**
+  1. Set `X` conservatively above the typical end-to-end pipeline runtime, including the prestate build.
+  2. Operators on slower hardware should raise `X` via the override flag before deploying.
+- **Detection:** `op-node` logs indicate it is behind and filling gap blocks. The gap size is `(mining_time - genesis_time) / L2BlockTime` blocks.
+- **Recovery Path(s):** No action required if the empty-block gap is acceptable. For deployments where the gap is unacceptable, redeploy with a larger `X`.
 
 ## Audit Requirements
+
+TBD
 
 ## Appendix
 
 ### Appendix A: CREATE2 Address Prediction
 
-The `eth_call` dry-run of `OPCM.deploy()` works because OPCM proxy deployments use CREATE2 with a salt that mixes in `msg.sender` and a `saltMixer` string from `FullConfig`. Given identical inputs (same sender, same config, same L1 state), the EVM deterministically produces the same addresses without writing to state. The dry-run must therefore use the same `from` address as the real broadcast, or the predicted addresses will differ.
+OPCM proxy deployments use CREATE2 with a salt derived from `msg.sender` and the `saltMixer` string in `FullConfig`. Given the same sender, config, and L1 state, the EVM produces the same addresses every time without writing to state. This is what makes the `eth_call` dry-run reliable: it runs the full deployment logic against current L1 state, returns the resulting `ChainContracts` struct, and leaves no trace on-chain.
+
+A dry-run from a different `from` address produces a different CREATE2 salt and different addresses. Any genesis built from those addresses will be invalid the moment the real deployment lands.

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -288,7 +288,7 @@ Runs after `DeployOPChain` completes. It confirms the deployed chain matches wha
 2. **`prestate`** computes the prestate hash from `rollup.json`, `genesis.json`, and `depsets.json` and writes it to the state. It is skipped when the intent carries a prestate override, which `op-deployer` resolves into the state instead.
 3. **`continue`** runs Steps 9–10: re-check the predicted addresses against current L1 state, submit `OPCM.deploy()` with `startingAnchorRoot` and the `absolutePrestate` read from the state, then run post-deploy validation.
 
-The prestate and the output root in the state are the hand-off point between the commands and the sole driver of continuation. `continue` reads them and proceeds only if they are set. If they are unset, the deployment halts.
+The prestate and the output root in the state are the hand-off point between the commands and the driver of continuation. For the default permissionless deployment, `continue` reads them and proceeds only if they are set; if they are unset, the deployment halts. The prestate gate is conditional on a permissionless game type being enabled as a permissioned deployment carries no prestate and can proceed without one.
 
 This is what lets a caller without Docker deploy: run `prepare`, have the prestate computed elsewhere, declare it as an override in the intent so `op-deployer` resolves it as the canonical prestate in the state (no build, no Docker), then run `continue`. A caller with Docker can instead run `prestate` to build it in place, all three commands in sequence.
 
@@ -324,8 +324,8 @@ No on-chain contract logic changes. Existing deployed chains are unaffected. The
 
 ## Impact on Developer Experience
 
-- Operators must set the prestate before deploying, either by running the `prestate` command or by declaring a precomputed prestate override in the intent. This adds to the end-to-end deployment time.
-- Permissionless games are valid from block 0, for mainnets, testnets, and devnets alike.
+- Operators deploying a permissionless chain must set the prestate before deploying, either by running the `prestate` command or by declaring a precomputed prestate override in the intent. This adds to the end-to-end deployment time. A permissioned-only deployment needs no prestate and skips this step.
+- With the default permissionless path, permissionless games are valid from block 0, for mainnets, testnets, and devnets alike.
 
 ## Alternatives Considered
 
@@ -339,7 +339,6 @@ A previous proposal considered breaking the cyclic dependency by making L2 genes
 
 - **Default X**: what is the right default offset between the anchor block timestamp and `genesis_time`? Needs benchmarking of the typical end-to-end pipeline runtime, including the prestate build.
 - **Re-run idempotency spec**: the exact skip conditions for `PredictL1Addresses`, `ComputeGenesisOutputRoot`, and the updated `GeneratePreState` need to be formally defined.
-- **Permissioned Games**: Should this still be supported?
 - **Docker-free callers**: the prepare/prestate/continue split lets an orchestrator without Docker run `prepare`, declare a prestate override in the intent, and run `continue`. Integration specifics for such callers are tracked separately.
 
 ---

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -253,9 +253,12 @@ The prestate is the starting point both sides of a dispute agree on. It is the C
 
 Because the chain config is embedded at compile time rather than fetched at runtime, the prestate hash is deterministic for a given chain config. Concretely: `rollup.json` contains `l2_time`, which is the genesis timestamp set at step 2.
 
-The prestate stage already exists in `op-deployer/pkg/deployer/pipeline/pre_state.go`. It takes `genesis.json`, `rollup.json`, and `depsets.json` as inputs, sends them to a build service, and stores the returned prestate hash in state. The only structural change is ordering: it currently runs after `DeployOPChain` and must move before it.
+The resolved prestate hash is written to the state, and the op-deployers reads `absolutePrestate` from there.
 
-This step requires a hosted prestate build service. `op-deployer` uploads `genesis.json`, `rollup.json`, and `depsets.json` to the URL configured via `--op-program-svc-url` (or `OP_DEPLOYER_OP_PROGRAM_SVC_URL`). The flag `--op-program-svc-url` must be set before running a full deployment.
+`op-deployer` derives that state value two ways, and treats the result identically:
+
+- **Computed.** A dedicated command builds the prestate from the Phase 1 artifacts and writes the hash to the state.
+- **From an override.** The operator declares a prestate override in the intent. `op-deployer` resolves it into the state prestate without building, so no build runs inside `op-deployer`.
 
 ### Step 9: Wiring into `OPCM.deploy()`
 
@@ -275,23 +278,28 @@ Runs after `DeployOPChain` completes. It confirms the deployed chain matches wha
 2. `AnchorStateRegistry` is seeded with the genesis output root computed in Step 6. Without this seed, the dispute game has no valid starting point.
 3. Guardian and system config addresses are set to the values in the intent. These gate privileged operations and must be confirmed before handing off to the operator.
 
-### `op-deployer` and Build Service Interaction
+### Pipeline commands: prepare, prestate, and continue
+
+`op-deployer` splits the flow into three commands around the **prestate boundary**:
+
+1. **`prepare`** runs Steps 1–7: pick the anchor, set `genesis_time`, predict the L1 addresses, run `L2Genesis`, build the genesis block, compute the output root, and emit `genesis.json`, `rollup.json`, and `depsets.json`. Pure off-chain computation, no L1 transaction, no Docker.
+2. **`prestate`** computes the prestate hash from `rollup.json`, `genesis.json`, and `depsets.json` and writes it to the state. It is skipped when the intent carries a prestate override, which `op-deployer` resolves into the state instead.
+3. **`continue`** runs Steps 9–10: submit `OPCM.deploy()` with `startingAnchorRoot` and the `absolutePrestate` read from the state, then run post-deploy validation.
+
+The prestate and the output root in the state are the hand-off point between the commands and the sole driver of continuation. `continue` reads them and proceeds only if they are set; if they are unset, the deployment halts.
+
+This is what lets a caller without Docker deploy: run `prepare`, have the prestate computed elsewhere, declare it as a prestate override in the intent, then run `continue`. A caller with Docker can run all three commands in sequence.
 
 ```mermaid
-sequenceDiagram
-    participant D as op-deployer
-    participant L1 as L1 RPC
-    participant B as Prestate build service
-
-    D->>L1: eth_call OPCM.deploy() [dry-run]
-    L1-->>D: ChainContracts (predicted addresses)
-    D->>D: Run L2Genesis with predicted addresses
-    D->>D: Build genesis block, compute output root
-    D->>B: genesis.json + rollup.json + depsets.json
-    B-->>D: PrestateManifest (chainID → prestate hash)
-    D->>L1: OPCM.deploy(outputRoot, prestateHash) [real tx]
-    L1-->>D: ChainContracts (deployed)
-    D-->>D: Post-Deploy Validation
+flowchart TD
+    A["prepare<br/>Steps 1–7 (off-chain)"] --> ART["genesis.json + rollup.json + depsets.json"]
+    ART --> B["prestate command<br/>compile to MIPS, Cannon hash (Docker)"]
+    B -->|"writes"| F["state: prestate"]
+    OV["prestate override<br/>declared in intent"] -.->|"resolved by op-deployer"| F
+    F --> G{"set?"}
+    G -->|"yes"| C["continue<br/>Steps 9–10: OPCM.deploy + validation"]
+    G -->|"no"| H["halt: deployment does not continue"]
+    C --> J["Permissionless game valid<br/>from L2 block 0"]
 ```
 
 ### Resource Usage
@@ -300,7 +308,7 @@ The prestate build moves from a deferred upgrade path to the critical path of ev
 
 ### Single Point of Failure and Multi Client Considerations
 
-The hosted prestate build service, when used, may represent a blocker for new chain deployments using permissionless proofs. The usage of an RPC also represents a point of failure for the loop to work properly.
+The prestate gates deployment through the state: `continue` does not proceed until the state prestate is set, whether computed by the `prestate` command or resolved from an intent override. The L1 RPC used for the `eth_call` dry-run and for `OPCM.deploy()` is a dependency for the loop to work properly.
 
 The design is client-agnostic and requires no changes on node clients. It is compatible with Cannon and Kona today and with future ZK fault-proof clients.
 

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -71,7 +71,7 @@ The proposed flow:
 5. Build the genesis block from the allocs, chain config, and genesis timestamp.
 6. Compute the L2 genesis output root from the genesis block.
 7. Generate `depsets.json`. For non-interop chains this contains only the chain itself.
-8. Build the prestate: `op-program` or `kona` compiles to MIPS with the chain config embedded, and Cannon hashes the initial machine state to produce the prestate hash.
+8. Commit the prestate: the prestate is built through the monorepo's `reproducible-prestate` or `reproducible-prestate-kona` recipes used today. The `prestate` command commits the hash back into the pipeline.
 9. Submit `OPCM.deploy()` carrying the real `startingAnchorRoot` and `absolutePrestate`.
 10. Chain starts. The permissionless dispute game is valid from block 0.
 
@@ -83,7 +83,7 @@ flowchart TD
     D --> E["Build genesis block</br>(allocs + config + genesis_time)"]
     E --> F["Compute genesis output root"]
     F --> G["Generate depsets.json"]
-    G --> H["Build prestate</br>(compile to MIPS, Cannon hash)"]
+    G --> H["Commit prestate hash</br>(through prestate command)"]
     H --> I["OPCM.deploy(outputRoot, prestateHash)"]
     I --> J["Chain starts</br>Permissionless dispute game valid from block 0"]
 ```
@@ -255,10 +255,12 @@ Because the chain config is embedded at compile time rather than fetched at runt
 
 The resolved prestate hash is written to the state, and `op-deployer` reads `absolutePrestate` from there.
 
-`op-deployer` derives that state value two ways, and treats the result identically:
+The `prestate` command commits the prestate to the `op-deployer` pipeline. It writes the externally built hash to the state from one of two sources and treats both identically:
 
-- **Computed.** A dedicated command builds the prestate from the Phase 1 artifacts and writes the hash to the state.
-- **From an override.** The operator declares a prestate override in the intent. `op-deployer` resolves it into the state prestate without building, so no build runs inside `op-deployer`.
+- **From a flag.** The caller passes the hash directly to the command.
+- **From an override.** The operator declares a prestate override in the intent. The command resolves it into the state.
+
+The command fails if neither source is provided. If both are provided, it fails only when the hashes disagree.
 
 ### Step 9: Wiring into `OPCM.deploy()`
 
@@ -285,19 +287,20 @@ Runs after `DeployOPChain` completes. It confirms the deployed chain matches wha
 `op-deployer` splits the flow into three commands around the **prestate boundary**:
 
 1. **`prepare`** runs Steps 1–7: pick the anchor, set `genesis_time`, predict the L1 addresses, run `L2Genesis`, build the genesis block, compute the output root, and emit `genesis.json`, `rollup.json`, and `depsets.json`. Pure off-chain computation, no L1 transaction, no Docker.
-2. **`prestate`** computes the prestate hash from `rollup.json`, `genesis.json`, and `depsets.json` and writes it to the state. It is skipped when the intent carries a prestate override, which `op-deployer` resolves into the state instead.
+2. **`prestate`** writes the prestate hash to the state, taking it from a command flag or from an override declared in the intent.
 3. **`continue`** runs Steps 9–10: re-check the predicted addresses against current L1 state, submit `OPCM.deploy()` with `startingAnchorRoot` and the `absolutePrestate` read from the state, then run post-deploy validation.
 
 The prestate and the output root in the state are the hand-off point between the commands and the driver of continuation. For the default permissionless deployment, `continue` reads them and proceeds only if they are set; if they are unset, the deployment halts. The prestate gate is conditional on a permissionless game type being enabled as a permissioned deployment carries no prestate and can proceed without one.
 
-This is what lets a caller without Docker deploy: run `prepare`, have the prestate computed elsewhere, declare it as an override in the intent so `op-deployer` resolves it as the canonical prestate in the state (no build, no Docker), then run `continue`. A caller with Docker can instead run `prestate` to build it in place, all three commands in sequence.
+A caller runs `prepare`, builds the prestate in the monorepo from the emitted artifacts, hands the hash to `prestate` through the flag or an intent override, and runs `continue`.
 
 ```mermaid
 flowchart TD
     A["prepare<br/>Steps 1–7 (off-chain)"] --> ART["genesis.json + rollup.json + depsets.json"]
-    ART --> B["prestate command<br/>compile to MIPS, Cannon hash (Docker)"]
+    ART -.-> BUILD["prestate built externally<br/>(reproducible-prestate recipes)"]
+    BUILD --> B["prestate command<br/>hash via flag or intent override"]
+    OV["prestate override<br/>declared in intent"] -.-> B
     B -->|"writes"| F["state: prestate"]
-    OV["prestate override<br/>declared in intent"] -.->|"resolved by op-deployer"| F
     F --> G{"set?"}
     G -->|"yes"| C["continue<br/>Steps 9–10: OPCM.deploy + validation"]
     G -->|"no"| H["halt: deployment does not continue"]
@@ -306,11 +309,11 @@ flowchart TD
 
 ### Resource Usage
 
-The prestate build moves from a deferred upgrade path to the critical path of every greenfield deployment that intends to use permissionless proofs. On `op-deployer`'s side, the end-to-end deployment time grows by the prestate build duration. There are no changes on node clients.
+The prestate build moves from a deferred upgrade path to the critical path of every greenfield deployment that intends to use permissionless proofs. The end-to-end deployment time grows by the prestate build duration. There are no changes on node clients.
 
 ### Single Point of Failure and Multi Client Considerations
 
-The prestate gates deployment through the state: `continue` does not proceed until the state prestate is set, whether computed by the `prestate` command or resolved from an intent override. The L1 RPC used for the `eth_call` dry-run and for `OPCM.deploy()` is a dependency for the loop to work properly.
+The prestate gates deployment through the state: `continue` does not proceed until the state prestate is set, whether passed to the `prestate` command as a flag or resolved from an intent override. The L1 RPC used for the `eth_call` dry-run and for `OPCM.deploy()` is a dependency for the loop to work properly.
 
 The design is client-agnostic and requires no changes on node clients. It is compatible with Cannon and Kona today and with future ZK fault-proof clients.
 
@@ -324,7 +327,7 @@ No on-chain contract logic changes. Existing deployed chains are unaffected. The
 
 ## Impact on Developer Experience
 
-- Operators deploying a permissionless chain must set the prestate before deploying, either by running the `prestate` command or by declaring a precomputed prestate override in the intent. This adds to the end-to-end deployment time. A permissioned-only deployment needs no prestate and skips this step.
+- Operators deploying a permissionless chain must set the prestate before deploying, through the `prestate` command flag or an intent override. This adds to the end-to-end deployment time. A permissioned-only deployment needs no prestate and skips this step.
 - With the default permissionless path, permissionless games are valid from block 0, for mainnets, testnets, and devnets alike.
 
 ## Alternatives Considered

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -1,0 +1,371 @@
+# Breaking the Cyclic Dependency
+
+|                    |                                    |
+| ------------------ | ---------------------------------- |
+| Author             | _Author Name_                      |
+| Created at         | _YYYY-MM-DD_                       |
+| Initial Reviewers  | _Reviewer Name 1, Reviewer Name 2_ |
+| Need Approval From | _Reviewer Name_                    |
+| Status             | _Draft_                            |
+
+## Purpose
+
+Eliminate the ~7-day permissioned window every new OP Stack chain currently incurs before its permissionless dispute game can activate. The window is a deployment tooling artifact, and this document specifies the tooling redesign that removes it.
+
+## Summary
+
+New OP Stack chains today launch under a permissioned dispute game for roughly a week. The deployment pipeline can't seed the L1 dispute system with a real anchor at deploy time, because the L2 genesis depends on L1 contract addresses and the L1 dispute system needs the resulting output root, and today's tooling can't satisfy both at once. It ships placeholder values and defers permissionless proofs until a real dispute resolves a week later.
+
+This design closes the gap by deriving everything off-chain before any transaction lands. `op-deployer` predicts the L1 contract addresses, builds the L2 genesis state and its output root, drives the prestate build, and finally submits `OPCM.deploy()` with the real values. The dispute system is seeded atomically with L1 contract deployment, and the permissionless game is valid from L2 block 0. No on-chain contract logic changes, the work lives entirely in tooling orchestration.
+
+## Problem Statement + Context
+
+Launching a new OP Stack chain forces a hard ordering: deploy L1 contracts first, then generate the L2 genesis using the addresses those contracts land at.
+
+The L2 genesis embeds L1 contract addresses directly into the chain's starting state. Those addresses are only known after OPCM runs, so the genesis cannot exist before the L1 deployment. And because the genesis is unknown at deploy time, `AnchorStateRegistry` cannot be seeded with a valid output root.
+
+Every new chain spends its first `~7 days` in a permissioned state. The permissionless dispute game cannot activate until `AnchorStateRegistry` holds a valid anchor state, and that requires a real output root to be finalized. Under the dispute game's finality delay, that takes about a week.
+
+This is a sequencing problem in the deployment tooling, not a protocol constraint.
+
+### The Cyclic Dependency
+
+`op-deployer` runs two sequential stages. First it calls OPCM on L1 to deploy all L1 contracts. Then it runs `L2Genesis.s.sol`, passing the newly-known L1 addresses as inputs to configure the L2 predeploys.
+
+The genesis output root cannot be computed until the genesis exists. The genesis cannot be produced until the L1 contracts exist. OPCM cannot seed `AnchorStateRegistry` until it has the output root. This mutual dependency is what we call the **cyclic dependency problem**.
+
+```mermaid
+flowchart TD
+      A["OPCM.deploy()"]
+      B["L1 contract addresses"]
+      C["L2 genesis"]
+      D["Genesis output root"]
+
+      A -->|"emits"| B
+      B -->|"required to build"| C
+      C -->|"determines"| D
+      D -->|"required input to seed</br>AnchorStateRegistry"| A
+
+      style A fill:#ff6b6b,color:#000
+      style D fill:#ff6b6b,color:#000
+```
+
+Today's tooling resolves the cycle by deferring the L1 commitments: hardcoded `startingAnchorRoot = 0xdead`, only `PERMISSIONED_CANNON` enabled, and retrofit later.
+
+**Out of scope for this milestone**
+
+- **Shared super dispute game deployments**: Since chains can be deployed today even into a shared dependency set while keeping separate per-chain dispute games.
+- **Prestate build consolidation**: The existing hosted-service architecture for prestate generation is preserved as-is.
+
+## Proposed Solution
+
+The pipeline shifts from "deploy first, derive everything after" to "derive everything off-chain, then submit a fully-specified deploy". This is possible since the current deployment can be predicted given the configs and constants, so that it is possible to known everything beforehand and get a predictable behavior during the deployment.
+
+### High-level flow
+
+The proposed flow will be as follows:
+
+1. Pick the L1 block as the anchor reference.
+2. Set the L2 genesis timestamp to the anchor's timestamp plus a configurable offset `X`.
+3. Predict the L1 contract addresses by running an `eth_call` dry-run of `OPCM.deploy()`.
+4. Run `L2Genesis.s.sol` with the predicted addresses to produce the chain-specific L2 allocs.
+5. Build the genesis block from the allocs, chain config, and genesis timestamp.
+6. Compute the L2 genesis output root from the genesis block.
+7. Generating `depsets.json`. For non-interop chains this contains only the chain itself.
+8. Build the prestate: `op-program` or `kona` compiles to MIPS with the chain config embedded, and Cannon hashes the initial machine state to produce the prestate hash.
+9. Submit `OPCM.deploy()` carrying the real `startingAnchorRoot` and `absolutePrestate`.
+10. Chain starts. The permissionless dispute game is valid from block 0.
+
+```mermaid
+flowchart TD
+    A["Pick L1 anchor block"] --> B["Set genesis_time = l1AnchorBlock.timestamp + X"]
+    B --> C["Predict L1 addresses</br>(eth_call dry-run)"]
+    C --> D["Run L2Genesis with predicted addresses"]
+    D --> E["Build genesis block</br>(allocs + config + genesis_time)"]
+    E --> F["Compute genesis output root"]
+    F --> G["Generate depsets.json"]
+    G --> H["Build prestate</br>(compile to MIPS, Cannon hash)"]
+    H --> I["OPCM.deploy(outputRoot, prestateHash)"]
+    I --> J["Chain starts</br>Permissionless dispute game valid from block 0"]
+```
+
+The numbered steps below detail each stage.
+
+### Step 1: Picking the L1 Anchor Block
+
+The L1 anchor block is the L2 chain's immutable reference point on L1. The artifacts `rollup.json`, the prestate, and the L2 genesis block header all depend on it. The anchor records the `hash`, `number`, and `timestamp`.
+
+Picking a block that later gets reorged out invalidates `rollup.json` and the prestate, requiring a full redeployment. Only blocks at the `safe` tag or deeper are eligible. `op-deployer` can pick a block e.g., the latest safe block at the time `deploy` is executed. Safe blocks take one epoch (~6 minutes) to finalize on L1, so the anchor will trail the wall clock by that margin. In this case, a drift of a few minutes is acceptable.
+
+**Reorg Safety**
+
+The anchor's hash is baked into `rollup.json`, which is used to generate the prestate at build time. If Ethereum reorgs past the anchor after deployment, the chain will be unable to start.
+
+### Step 2: Setting the Genesis Timestamp
+
+The genesis timestamp is a direct input to two artifacts:
+
+- The **genesis block header**, which determines the genesis block hash.
+- The genesis time in the `rollup.json` file, which the fault proof program reads at compile time.
+- The **genesis output root**, derived from the genesis block hash.
+
+Through these, it transitively determines the genesis block hash, the genesis output root (which includes the block hash), and the prestate hash (which embeds `rollup.json`). A different timestamp produces a different value for every downstream artifact.
+
+```
+genesis_time = l1AnchorBlock.timestamp + X
+```
+
+X is a value the operator **commits** to during the deployment. Everything else follows deterministically from the anchor block and X.
+
+#### The deployment window
+
+Between fixing `genesis_time` (Step 2) and `OPCM.deploy()` being mined (Step 9), wall-clock time elapses while Steps 3–8 run. The dominant cost is the Docker-based prestate build (Step 8, minutes). The correctness of the deployment depends on `genesis_time` being in the future when `OPCM.deploy()` is mined.
+
+```mermaid
+sequenceDiagram
+    participant D as op-deployer
+    participant L1 as L1 chain
+    participant N as op-node
+
+    D->>D: Step 1: pick anchor block (timestamp = T)
+    D->>D: Step 2: genesis_time = T + X
+    D->>D: Steps 3–8: compute all artifacts
+    D->>L1: Step 9: OPCM.deploy(outputRoot, prestateHash)
+    Note over L1: block.timestamp < genesis_time ✓
+    L1-->>D: ChainContracts deployed
+    Note over N: op-node starts, waits for genesis_time
+    Note over L1: wall clock reaches genesis_time
+    N->>N: Block 1 produced cleanly
+```
+
+**Nominal case (`genesis_time` still in the future when `OPCM.deploy()` is mined):**
+
+- `AnchorStateRegistry` contract is seeded with the correct genesis output root.
+- `op-node` starts but does not produce blocks until wall clock reaches the genesis time.
+- Block 1 is produced cleanly at the `genesis_time + L2BlockTime`.
+- Portal deposits made between `OPCM.deploy()` and the genesis time are included in the first L2 blocks via normal derivation.
+
+**Overrun case (`genesis_time` has already passed when `OPCM.deploy()` is mined):**
+
+- The deployment succeeds. There is no on-chain guard against this.
+- `op-node` sees it is behind and fills the gap with empty blocks at `L2BlockTime` intervals.
+- A 10-minute overrun produces ~300 empty blocks before any user transaction can land.
+
+#### Choosing X
+
+`X` must cover:
+
+1. Anchor-block staleness when `op-deployer` reads it.
+2. Full runtime of steps 3-8.
+3. L1 inclusion latency for the `OPCM.deploy()` transaction.
+
+The Docker-based prestate build in step 8 is the bottleneck. The default X should be set conservatively above the typical build time. Operators running faster build infrastructure can lower it via the override flag; operators on slower hardware should raise it.
+
+### Step 3: Predicting L1 Addresses
+
+`L2Genesis.s.sol` consumes three L1 proxy addresses: `L1CrossDomainMessenger`, `L1StandardBridge`, and `L1ERC721Bridge`. Those contracts don't exist yet when the genesis is built, so their addresses must be predicted before any deployment transaction is sent.
+
+Meanwhile, `OptimismPortal` and `SystemConfig` are also predicted to be written into `rollup.json`.
+
+#### `eth_call` dry-run
+
+Call `OPCM.deploy()` with the full `FullConfig` without broadcasting the transaction. The EVM executes against current L1 state and returns the `ChainContracts` struct containing all proxy addresses, without writing anything on-chain.
+
+```solidity
+// Represents the full configuration of a
+// chain deployment in the OPContractsManagerV2
+struct FullConfig {
+	// Deployment
+	string saltMixer;
+	ISuperchainConfig superchainConfig;
+	// Roles
+	address proxyAdminOwner;
+	address systemConfigOwner;
+	address unsafeBlockSigner;
+	address batcher;
+	// Anchor state (seeded with genesis output root)
+	Proposal startingAnchorRoot;
+	GameType startingRespectedGameType;
+	// L2 config
+	uint32 basefeeScalar;
+	uint32 blobBasefeeScalar;
+	uint64 gasLimit;
+	uint256 l2ChainId;
+	IResourceMetering.ResourceConfig resourceConfig;
+	// Dispute games
+	IOPContractsManagerUtils.DisputeGameConfig[] disputeGameConfigs;
+	bool useCustomGasToken;
+}
+```
+
+The dry-run must be sent `from` the same address that will broadcast the real `OPCM.deploy()` transaction. OPCM mixes `msg.sender` into the CREATE2 salt for every proxy deployment. A dry-run from a different address produces different predicted addresses, and the genesis built from them will be invalid.
+
+### Step 4: Generating L2 Allocs
+
+The `L2Genesis.s.sol` produces the L2 genesis state with the set of accounts, code and storage. This generates the `stateRoot`.
+
+### Step 5: Building the Genesis Block
+
+The genesis block is L2 block 0. Its header fields are sourced as follows:
+
+| **Field**                                                                                  | **Source**                                                                                 |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `parentHash`                                                                               | `0x00…00` (no parent)                                                                      |
+| `uncleHash`                                                                                | empty list hash                                                                            |
+| `coinbase`                                                                                 | `predeploys.SequencerFeeVaultAddr`                                                         |
+| `stateRoot`                                                                                | Step 4                                                                                     |
+| `transactionsRoot`                                                                         | empty trie root                                                                            |
+| `receiptsRoot`                                                                             | empty trie root                                                                            |
+| `logsBloom`                                                                                | zeros                                                                                      |
+| `difficulty`                                                                               | 0                                                                                          |
+| `number`                                                                                   | 0 (`L2GenesisBlockNumber`)                                                                 |
+| `gasLimit`                                                                                 | chain config (`L2GenesisBlockGasLimit`)                                                    |
+| `gasUsed`                                                                                  | 0 (`L2GenesisBlockGasUsed`)                                                                |
+| `timestamp`                                                                                | `genesis_time` from Step 2                                                                 |
+| `extraData`                                                                                | Hardfork determined                                                                        |
+| `mixHash`                                                                                  | 0 (`L2GenesisBlockMixHash`)                                                                |
+| `nonce`                                                                                    | 0 (`L2GenesisBlockNonce`)                                                                  |
+| `baseFee`                                                                                  | 1 gwei                                                                                     |
+| `withdrawalsRoot`, `blobGasUsed`, `excessBlobGas`, `parentBeaconBlockRoot`, `requestsRoot` | per-hardfork standard genesis values (Empty or zero if hardforks are activated at genesis) |
+
+The block hash is the keccak256 of the RLP-encoded header. Given fixed inputs from earlier stages, it is deterministic.
+
+### Step 6: Computing the Genesis Output Root
+
+`AnchorStateRegistry` stores a `Proposal { root, l2SequenceNumber }` as the chain's starting anchor. Dispute games are played against roots that descend from this anchor. Seeding it with the genesis output root means the permissionless game is valid from block 0.
+
+The output root is computed from the genesis block:
+
+```
+outputRoot = keccak256(version || stateRoot || messagePasserStorageRoot || blockHash)
+```
+
+`version` is 32 zero bytes (OutputV0). `messagePasserStorageRoot` is the storage root of `L2ToL1MessagePasser` at genesis. `blockHash` is the genesis block hash.
+
+This root is passed as `startingAnchorRoot` to `OPCM.deploy()` at step 9, with `l2SequenceNumber` as 0.
+
+### Step 7: Generating `depset.json`
+
+The dependency set will contain only the chain itself. The `depset.json` file enumerates the chains the proof program needs to know about. Generation is unchanged from the current pipeline: a single-chain depset for standalone deployments, and a multi-chain depset for shared-depset deployments. Note that deploying chains directly into a shared super dispute game is not supported and is out of scope for this milestone.
+
+### Step 8: Prestate Generation
+
+The prestate is the starting point both sides of a dispute agree on. It is the Cannon hash of the initial MIPS machine state produced by compiling `op-program` or `kona` with the chain config baked in.
+
+Because the chain config is embedded at compile time rather than fetched at runtime, the prestate hash is deterministic for a given chain config. Concretely: `rollup.json` contains `l2_time`, which is the genesis timestamp set at step 2.
+
+The prestate stage already exists in `op-deployer/pkg/deployer/pipeline/pre_state.go`. It takes `genesis.json`, `rollup.json`, and `depsets.json` as inputs, sends them to a build service, and stores the returned prestate hash in state. The only structural change is ordering: it currently runs after `DeployOPChain` and must move before it.
+
+This step requires a hosted prestate build service. `op-deployer` uploads `genesis.json`, `rollup.json`, and `depsets.json` to the URL configured via `--op-program-svc-url` (or `OP_DEPLOYER_OP_PROGRAM_SVC_URL`). The flag `--op-program-svc-url` must be set before running a full deployment.
+
+### Step 9: Wiring into `OPCM.deploy()`
+
+`OPCM.deploy()` already accepts the two fields this design fills in: `startingAnchorRoot` is set to the genesis output root from Step 6 with sequence number 0, and each entry in `disputeGameConfigs` carries its corresponding prestate hash from Step 8 inside `absolutePrestate`.
+
+Three call-site changes are required:
+
+1. In the OP Chain deployment script, the require guard that currently restricts game types to `PERMISSIONED_CANNON` at initial deployment is removed; `CANNON` and `CANNON_KONA` are enabled with their respective prestate hashes from the manifest; and the hardcoded `0xdead` placeholder for the starting anchor root is replaced with the computed genesis output root.
+2. The Go-side input struct for the OP Chain deployment gains a `StartingAnchorRoot` field and per-game-type prestate-hash fields.
+3. op-deployer's chain orchestration code wires those new fields through into the FullConfig passed to OPCM.
+
+### Step 10: Post Deploy verification
+
+Runs after `DeployOPChain` completes. It confirms the deployed chain matches what was computed in earlier pipeline steps.
+
+1. The actual deployed L1 contract addresses match the predicted addresses from Step 3. A mismatch means the L2 genesis was built against the wrong state and the chain is unsafe to operate.
+2. `AnchorStateRegistry` is seeded with the genesis output root computed in Step 6. Without this seed, the dispute game has no valid starting point.
+3. Guardian and system config addresses are set to the values in the intent. These gate privileged operations and must be confirmed before handing off to the operator.
+
+### `op-deployer` and Build Service Interaction
+
+```mermaid
+sequenceDiagram
+    participant D as op-deployer
+    participant L1 as L1 RPC
+    participant B as Prestate build service
+
+    D->>L1: eth_call OPCM.deploy() [dry-run]
+    L1-->>D: ChainContracts (predicted addresses)
+    D->>D: Run L2Genesis with predicted addresses
+    D->>D: Build genesis block, compute output root
+    D->>B: genesis.json + rollup.json + depsets.json
+    B-->>D: PrestateManifest (chainID → prestate hash)
+    D->>L1: OPCM.deploy(outputRoot, prestateHash) [real tx]
+    L1-->>D: ChainContracts (deployed)
+    D-->>D: Post-Deploy Validation
+```
+
+### Resource Usage
+
+The prestate build moves from a deferred upgrade path to the critical path of every greenfield deployment that intends to use permissionless proofs. On `op-deployer`'s side, the end-to-end deployment time grows by the prestate build duration. There are no changes on node clients.
+
+### Single Point of Failure and Multi Client Considerations
+
+The hosted prestate build service, when used, may represent a blocker for new chain deployments using permissionless proofs. The usage of an RPC also represents a point of failure for the loop to work properly.
+
+The design is client-agnostic and requires no changes on node clients. It is compatible with Cannon and Kona today and with future ZK fault-proof clients.
+
+## Failure Mode Analysis
+
+See [fma.md](./fma.md).
+
+## Backward Compatibility
+
+No on-chain contract logic changes. Existing deployed chains are unaffected. The `op-deployer` pipeline change replaces the previous `startingAnchorRoot = 0xdead` flow; no compatibility layer is provided.
+
+Operators running `op-deployer` must configure `--op-program-svc-url` (or `OP_DEPLOYER_OP_PROGRAM_SVC_URL`) before executing a deployment with permissionless proofs.
+
+## Impact on Developer Experience
+
+- Operators must configure a reachable build service when using permissionless proofs, impacting the end-to-end deployment time
+- Permissioness games are possible from block 0, highly useful for all cases: mainnets, testnets and devnets.
+
+## Alternatives Considered
+
+### Standard Allocs + Chain Init Transaction
+
+A previous proposal considered breaking the cyclic dependency by making L2 genesis allocs chain-agnostic, and injecting chain-specific data via a `chainInitTx` system transaction. However, it was rejected since it requires `op-node`, `op-program` and `kona` changes without actually providing real value since that did not avoid per-chain prestate.
+
+## Risks & Uncertainties
+
+### Hosted-service Dependency
+
+The prestate build service is on the critical path of every greenfield deployment for permissionless proofs. This creates operational concentration that did not exist under the old desigh, where prestate generation was optional and deferred.
+
+### Open Questions
+
+- **Prestate service hosting**: who provides a hosted build service endpoint for operators?
+- **Default X**: what is the right default offset between the anchor block timestamp and `genesis_time`? Needs benchmarking against a real build service to determine typical end-to-end pipeline runtime.
+- **Re-run idempotency spec**: the exact skip conditions for `PredictL1Addresses`, `ComputeGenesisOutputRoot`, and the updated `GeneratePreState` need to be formally defined.
+- **Permissioned Games**: Should this still be supported?
+- **Netchef…**
+
+---
+
+## Glossary
+
+**Output root**
+
+A 32-byte commitment to the L2 state at a specific block, computed as:
+
+```jsx
+keccak256(version || stateRoot || messagePasserStorageRoot || blockHash);
+```
+
+`version` is 32 zero bytes. `AnchorStateRegistry` stores the genesis output root as the starting anchor. All dispute games trace back to it.
+
+**Prestate / prestate hash**
+
+The agreed starting point for a fault proof dispute. It is the Cannon hash of the initial MIPS machine state produced by compiling `op-program` (Go) or `kona` (Rust) with the chain config baked in. Because the chain config is embedded at compile time, the prestate hash is deterministic for a given chain config. Both the challenger and defender must agree on this hash before a dispute can proceed.
+
+**Genesis block**
+
+L2 block 0. It has no parent (`parentHash = 0x00...00`) and contains no transactions. Its header fields are derived from the L2 allocs (state root), the chain config, and the genesis timestamp. The block hash is `keccak256(RLP(header))` and feeds directly into the genesis output root.
+
+**Chain config**
+
+The set of parameters that define the chain: hardfork activation blocks or timestamps, genesis block parameters (gas limit, base fee), and the L1 anchor block reference. Stored across `rollup.json` and `genesis.json`. The fault proof program reads `rollup.json` at compile time, which is why a different genesis timestamp produces a different prestate hash.
+
+**L2 allocs**
+
+The initial account and storage layout of the L2 chain, produced by running `L2Genesis.s.sol` with the L1 contract addresses as inputs. It defines which predeploy contracts exist at genesis, their bytecode, and their starting storage. The Merkle root of this layout becomes the `stateRoot` field of the genesis block header.

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -14,7 +14,7 @@ Eliminate the ~7-day permissioned window every new OP Stack chain currently incu
 
 ## Summary
 
-New OP Stack chains today launch under a permissioned dispute game for roughly a week. The deployment pipeline can't seed the L1 dispute system with a real anchor at deploy time, because the L2 genesis depends on L1 contract addresses and the L1 dispute system needs the resulting output root, and today's tooling can't satisfy both at once. It ships placeholder values and defers permissionless proofs until a real dispute resolves a week later.
+New OP Stack chains today launch under a permissioned dispute game for roughly a week. The deployment pipeline can't seed the L1 dispute system with a real anchor at deploy time. The L2 genesis depends on L1 contract addresses, and the L1 dispute system needs the resulting output root, so today's tooling can't satisfy both at once. It ships placeholder values and defers permissionless proofs until a real dispute resolves a week later.
 
 This design closes the gap by deriving everything off-chain before any transaction lands. `op-deployer` predicts the L1 contract addresses, builds the L2 genesis state and its output root, obtains the prestate hash, and finally submits `OPCM.deploy()` with the real values. The dispute system is seeded atomically with L1 contract deployment, and the permissionless game is valid from L2 block 0.
 
@@ -58,11 +58,11 @@ Today's tooling resolves the cycle by deferring the L1 commitments: hardcoded `s
 
 ## Proposed Solution
 
-The pipeline shifts from "deploy first, derive everything after" to "derive everything off-chain, then submit a fully-specified deploy". This is possible since the current deployment can be predicted given the configs and constants, so that it is possible to known everything beforehand and get a predictable behavior during the deployment.
+The pipeline shifts from "deploy first, derive everything after" to "derive everything off-chain, then submit a fully-specified deploy". This works because the deployment is deterministic. Given the configs and constants, every value can be computed before the deploy transaction is sent.
 
 ### High-level flow
 
-The proposed flow will be as follows:
+The proposed flow:
 
 1. Pick the L1 block as the anchor reference.
 2. Set the L2 genesis timestamp to the anchor's timestamp plus a configurable offset `X`.
@@ -70,7 +70,7 @@ The proposed flow will be as follows:
 4. Run `L2Genesis.s.sol` with the predicted addresses to produce the chain-specific L2 allocs.
 5. Build the genesis block from the allocs, chain config, and genesis timestamp.
 6. Compute the L2 genesis output root from the genesis block.
-7. Generating `depsets.json`. For non-interop chains this contains only the chain itself.
+7. Generate `depsets.json`. For non-interop chains this contains only the chain itself.
 8. Build the prestate: `op-program` or `kona` compiles to MIPS with the chain config embedded, and Cannon hashes the initial machine state to produce the prestate hash.
 9. Submit `OPCM.deploy()` carrying the real `startingAnchorRoot` and `absolutePrestate`.
 10. Chain starts. The permissionless dispute game is valid from block 0.
@@ -94,7 +94,7 @@ The numbered steps below detail each stage.
 
 The L1 anchor block is the L2 chain's immutable reference point on L1. The artifacts `rollup.json`, the prestate, and the L2 genesis block header all depend on it. The anchor records the `hash`, `number`, and `timestamp`.
 
-Picking a block that later gets reorged out invalidates `rollup.json` and the prestate, requiring a full redeployment. Only blocks at the `safe` tag or deeper are eligible. `op-deployer` can pick a block e.g., the latest safe block at the time `deploy` is executed. Safe blocks take one epoch (~6 minutes) to finalize on L1, so the anchor will trail the wall clock by that margin. In this case, a drift of a few minutes is acceptable.
+Picking a block that later gets reorged out invalidates `rollup.json` and the prestate, requiring a full redeployment. Only blocks at the `safe` tag or deeper are eligible. `op-deployer` can pick the latest safe block at the time `deploy` is executed. Safe blocks take one epoch (~6 minutes) to finalize on L1, so the anchor will trail the wall clock by that margin. In this case, a drift of a few minutes is acceptable.
 
 **Reorg Safety**
 
@@ -158,7 +158,7 @@ sequenceDiagram
 2. Full runtime of steps 3-8.
 3. L1 inclusion latency for the `OPCM.deploy()` transaction.
 
-The Docker-based prestate build in step 8 is the bottleneck. The default X should be set conservatively above the typical build time. Operators running faster build infrastructure can lower it via the override flag; operators on slower hardware should raise it.
+The Docker-based prestate build in step 8 is the bottleneck. The default X should be set conservatively above the typical build time. Operators running faster build infrastructure can lower it via the override flag. Operators on slower hardware should raise it.
 
 ### Step 3: Predicting L1 Addresses
 
@@ -201,7 +201,7 @@ The dry-run must be sent `from` the same address that will broadcast the real `O
 
 ### Step 4: Generating L2 Allocs
 
-The `L2Genesis.s.sol` produces the L2 genesis state with the set of accounts, code and storage. This generates the `stateRoot`.
+The `L2Genesis.s.sol` produces the L2 genesis state with the set of accounts, code, and storage. This generates the `stateRoot`.
 
 ### Step 5: Building the Genesis Block
 
@@ -243,9 +243,9 @@ outputRoot = keccak256(version || stateRoot || messagePasserStorageRoot || block
 
 This root is passed as `startingAnchorRoot` to `OPCM.deploy()` at step 9, with `l2SequenceNumber` as 0.
 
-### Step 7: Generating `depset.json`
+### Step 7: Generating `depsets.json`
 
-The dependency set will contain only the chain itself. The `depset.json` file enumerates the chains the proof program needs to know about. Generation is unchanged from the current pipeline: a single-chain depset for standalone deployments, and a multi-chain depset for shared-depset deployments. Note that deploying chains directly into a shared super dispute game is not supported and is out of scope for this milestone.
+The dependency set will contain only the chain itself. The `depsets.json` file enumerates the chains the proof program needs to know about. Generation is unchanged from the current pipeline: a single-chain depset for standalone deployments, and a multi-chain depset for shared-depset deployments. Deploying chains directly into a shared super dispute game is not supported and is out of scope for this milestone.
 
 ### Step 8: Prestate Generation
 
@@ -253,7 +253,7 @@ The prestate is the starting point both sides of a dispute agree on. It is the C
 
 Because the chain config is embedded at compile time rather than fetched at runtime, the prestate hash is deterministic for a given chain config. Concretely: `rollup.json` contains `l2_time`, which is the genesis timestamp set at step 2.
 
-The resolved prestate hash is written to the state, and the op-deployers reads `absolutePrestate` from there.
+The resolved prestate hash is written to the state, and `op-deployer` reads `absolutePrestate` from there.
 
 `op-deployer` derives that state value two ways, and treats the result identically:
 
@@ -266,11 +266,11 @@ The resolved prestate hash is written to the state, and the op-deployers reads `
 
 Three call-site changes are required:
 
-1. In the OP Chain deployment script, the require guard that currently restricts game types to `PERMISSIONED_CANNON` at initial deployment is removed; `CANNON` and `CANNON_KONA` are enabled with their respective prestate hashes read from the prestate field; and the hardcoded `0xdead` placeholder for the starting anchor root is replaced with the computed genesis output root.
+1. The OP Chain deployment script changes in three places. The require guard that restricts game types to `PERMISSIONED_CANNON` at initial deployment is removed. `CANNON` and `CANNON_KONA` are enabled with their respective prestate hashes read from the state. The hardcoded `0xdead` placeholder for the starting anchor root is replaced with the computed genesis output root.
 2. The Go-side input struct for the OP Chain deployment gains a `StartingAnchorRoot` field and per-game-type prestate-hash fields.
 3. op-deployer's chain orchestration code wires those new fields through into the FullConfig passed to OPCM.
 
-### Step 10: Post Deploy verification
+### Step 10: Post-Deploy Verification
 
 Runs after `DeployOPChain` completes. It confirms the deployed chain matches what was computed in earlier pipeline steps.
 
@@ -286,7 +286,7 @@ Runs after `DeployOPChain` completes. It confirms the deployed chain matches wha
 2. **`prestate`** computes the prestate hash from `rollup.json`, `genesis.json`, and `depsets.json` and writes it to the state. It is skipped when the intent carries a prestate override, which `op-deployer` resolves into the state instead.
 3. **`continue`** runs Steps 9–10: submit `OPCM.deploy()` with `startingAnchorRoot` and the `absolutePrestate` read from the state, then run post-deploy validation.
 
-The prestate and the output root in the state are the hand-off point between the commands and the sole driver of continuation. `continue` reads them and proceeds only if they are set; if they are unset, the deployment halts.
+The prestate and the output root in the state are the hand-off point between the commands and the sole driver of continuation. `continue` reads them and proceeds only if they are set. If they are unset, the deployment halts.
 
 This is what lets a caller without Docker deploy: run `prepare`, have the prestate computed elsewhere, declare it as a prestate override in the intent, then run `continue`. A caller with Docker can run all three commands in sequence.
 
@@ -318,18 +318,18 @@ See [fma.md](./fma.md).
 
 ## Backward Compatibility
 
-No on-chain contract logic changes. Existing deployed chains are unaffected. The `op-deployer` pipeline change replaces the previous `startingAnchorRoot = 0xdead` flow; no compatibility layer is provided.
+No on-chain contract logic changes. Existing deployed chains are unaffected. The `op-deployer` pipeline change replaces the previous `startingAnchorRoot = 0xdead` flow. No compatibility layer is provided.
 
 ## Impact on Developer Experience
 
 - Operators must set the prestate before deploying, either by running the `prestate` command or by declaring a precomputed prestate override in the intent. This adds to the end-to-end deployment time.
-- Permissioness games are possible from block 0, highly useful for all cases: mainnets, testnets and devnets.
+- Permissionless games are valid from block 0, for mainnets, testnets, and devnets alike.
 
 ## Alternatives Considered
 
 ### Standard Allocs + Chain Init Transaction
 
-A previous proposal considered breaking the cyclic dependency by making L2 genesis allocs chain-agnostic, and injecting chain-specific data via a `chainInitTx` system transaction. However, it was rejected since it requires `op-node`, `op-program` and `kona` changes without actually providing real value since that did not avoid per-chain prestate.
+A previous proposal considered breaking the cyclic dependency by making L2 genesis allocs chain-agnostic and injecting chain-specific data through a `chainInitTx` system transaction. It was rejected. It requires changes to `op-node`, `op-program`, and `kona`, and still does not avoid a per-chain prestate.
 
 ## Risks & Uncertainties
 

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -270,6 +270,8 @@ Three call-site changes are required:
 2. The Go-side input struct for the OP Chain deployment gains a `StartingAnchorRoot` field and per-game-type prestate-hash fields.
 3. op-deployer's chain orchestration code wires those new fields through into the FullConfig passed to OPCM.
 
+**Pre-broadcast preflight.** Before broadcasting, `continue` re-runs the Step 3 `eth_call` dry-run against the RPC that will receive the real transaction and asserts the returned `ChainContracts` match the L1 addresses baked into the committed `genesis.json` and `rollup.json`. A mismatch aborts the deployment before the any `OPCM.deploy()` transaction is sent. This catches a changed sender, an L1-state or OPCM change during the deployment window, or a divergent RPC, while the failure is still cheap to recover from.
+
 ### Step 10: Post-Deploy Verification
 
 Runs after `DeployOPChain` completes. It confirms the deployed chain matches what was computed in earlier pipeline steps.
@@ -284,7 +286,7 @@ Runs after `DeployOPChain` completes. It confirms the deployed chain matches wha
 
 1. **`prepare`** runs Steps 1–7: pick the anchor, set `genesis_time`, predict the L1 addresses, run `L2Genesis`, build the genesis block, compute the output root, and emit `genesis.json`, `rollup.json`, and `depsets.json`. Pure off-chain computation, no L1 transaction, no Docker.
 2. **`prestate`** computes the prestate hash from `rollup.json`, `genesis.json`, and `depsets.json` and writes it to the state. It is skipped when the intent carries a prestate override, which `op-deployer` resolves into the state instead.
-3. **`continue`** runs Steps 9–10: submit `OPCM.deploy()` with `startingAnchorRoot` and the `absolutePrestate` read from the state, then run post-deploy validation.
+3. **`continue`** runs Steps 9–10: re-check the predicted addresses against current L1 state, submit `OPCM.deploy()` with `startingAnchorRoot` and the `absolutePrestate` read from the state, then run post-deploy validation.
 
 The prestate and the output root in the state are the hand-off point between the commands and the sole driver of continuation. `continue` reads them and proceeds only if they are set. If they are unset, the deployment halts.
 

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -249,7 +249,7 @@ The dependency set will contain only the chain itself. The `depsets.json` file e
 
 ### Step 8: Prestate Generation
 
-The prestate is the starting point both sides of a dispute agree on. It is the Cannon hash of the initial MIPS machine state produced by compiling `op-program` or `kona` with the chain config baked in.
+The prestate is the starting point both sides of a dispute agree on. It is the Cannon hash of the initial MIPS machine state produced by compiling `kona` with the chain config baked in.
 
 Because the chain config is embedded at compile time rather than fetched at runtime, the prestate hash is deterministic for a given chain config. Concretely: `rollup.json` contains `l2_time`, which is the genesis timestamp set at step 2.
 
@@ -334,7 +334,7 @@ No on-chain contract logic changes. Existing deployed chains are unaffected. The
 
 ### Standard Allocs + Chain Init Transaction
 
-A previous proposal considered breaking the cyclic dependency by making L2 genesis allocs chain-agnostic and injecting chain-specific data through a `chainInitTx` system transaction. It was rejected. It requires changes to `op-node`, `op-program`, and `kona`, and still does not avoid a per-chain prestate.
+A previous proposal considered breaking the cyclic dependency by making L2 genesis allocs chain-agnostic and injecting chain-specific data through a `chainInitTx` system transaction. It was rejected. It requires changes to `op-node` and `kona`, and still does not avoid a per-chain prestate.
 
 ## Risks & Uncertainties
 
@@ -360,7 +360,7 @@ keccak256(version || stateRoot || messagePasserStorageRoot || blockHash);
 
 **Prestate / prestate hash**
 
-The agreed starting point for a fault proof dispute. It is the Cannon hash of the initial MIPS machine state produced by compiling `op-program` (Go) or `kona` (Rust) with the chain config baked in. Because the chain config is embedded at compile time, the prestate hash is deterministic for a given chain config. Both the challenger and defender must agree on this hash before a dispute can proceed.
+The agreed starting point for a fault proof dispute. It is the Cannon hash of the initial MIPS machine state produced by compiling `kona` with the chain config baked in. Because the chain config is embedded at compile time, the prestate hash is deterministic for a given chain config. Both the challenger and defender must agree on this hash before a dispute can proceed.
 
 **Genesis block**
 

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -16,7 +16,7 @@ Eliminate the ~7-day permissioned window every new OP Stack chain currently incu
 
 New OP Stack chains today launch under a permissioned dispute game for roughly a week. The deployment pipeline can't seed the L1 dispute system with a real anchor at deploy time, because the L2 genesis depends on L1 contract addresses and the L1 dispute system needs the resulting output root, and today's tooling can't satisfy both at once. It ships placeholder values and defers permissionless proofs until a real dispute resolves a week later.
 
-This design closes the gap by deriving everything off-chain before any transaction lands. `op-deployer` predicts the L1 contract addresses, builds the L2 genesis state and its output root, drives the prestate build, and finally submits `OPCM.deploy()` with the real values. The dispute system is seeded atomically with L1 contract deployment, and the permissionless game is valid from L2 block 0. No on-chain contract logic changes, the work lives entirely in tooling orchestration.
+This design closes the gap by deriving everything off-chain before any transaction lands. `op-deployer` predicts the L1 contract addresses, builds the L2 genesis state and its output root, obtains the prestate hash, and finally submits `OPCM.deploy()` with the real values. The dispute system is seeded atomically with L1 contract deployment, and the permissionless game is valid from L2 block 0.
 
 ## Problem Statement + Context
 
@@ -55,7 +55,6 @@ Today's tooling resolves the cycle by deferring the L1 commitments: hardcoded `s
 **Out of scope for this milestone**
 
 - **Shared super dispute game deployments**: Since chains can be deployed today even into a shared dependency set while keeping separate per-chain dispute games.
-- **Prestate build consolidation**: The existing hosted-service architecture for prestate generation is preserved as-is.
 
 ## Proposed Solution
 
@@ -264,7 +263,7 @@ This step requires a hosted prestate build service. `op-deployer` uploads `genes
 
 Three call-site changes are required:
 
-1. In the OP Chain deployment script, the require guard that currently restricts game types to `PERMISSIONED_CANNON` at initial deployment is removed; `CANNON` and `CANNON_KONA` are enabled with their respective prestate hashes from the manifest; and the hardcoded `0xdead` placeholder for the starting anchor root is replaced with the computed genesis output root.
+1. In the OP Chain deployment script, the require guard that currently restricts game types to `PERMISSIONED_CANNON` at initial deployment is removed; `CANNON` and `CANNON_KONA` are enabled with their respective prestate hashes read from the prestate field; and the hardcoded `0xdead` placeholder for the starting anchor root is replaced with the computed genesis output root.
 2. The Go-side input struct for the OP Chain deployment gains a `StartingAnchorRoot` field and per-game-type prestate-hash fields.
 3. op-deployer's chain orchestration code wires those new fields through into the FullConfig passed to OPCM.
 
@@ -313,11 +312,9 @@ See [fma.md](./fma.md).
 
 No on-chain contract logic changes. Existing deployed chains are unaffected. The `op-deployer` pipeline change replaces the previous `startingAnchorRoot = 0xdead` flow; no compatibility layer is provided.
 
-Operators running `op-deployer` must configure `--op-program-svc-url` (or `OP_DEPLOYER_OP_PROGRAM_SVC_URL`) before executing a deployment with permissionless proofs.
-
 ## Impact on Developer Experience
 
-- Operators must configure a reachable build service when using permissionless proofs, impacting the end-to-end deployment time
+- Operators must set the prestate before deploying, either by running the `prestate` command or by declaring a precomputed prestate override in the intent. This adds to the end-to-end deployment time.
 - Permissioness games are possible from block 0, highly useful for all cases: mainnets, testnets and devnets.
 
 ## Alternatives Considered
@@ -328,17 +325,12 @@ A previous proposal considered breaking the cyclic dependency by making L2 genes
 
 ## Risks & Uncertainties
 
-### Hosted-service Dependency
-
-The prestate build service is on the critical path of every greenfield deployment for permissionless proofs. This creates operational concentration that did not exist under the old desigh, where prestate generation was optional and deferred.
-
 ### Open Questions
 
-- **Prestate service hosting**: who provides a hosted build service endpoint for operators?
-- **Default X**: what is the right default offset between the anchor block timestamp and `genesis_time`? Needs benchmarking against a real build service to determine typical end-to-end pipeline runtime.
+- **Default X**: what is the right default offset between the anchor block timestamp and `genesis_time`? Needs benchmarking of the typical end-to-end pipeline runtime, including the prestate build.
 - **Re-run idempotency spec**: the exact skip conditions for `PredictL1Addresses`, `ComputeGenesisOutputRoot`, and the updated `GeneratePreState` need to be formally defined.
 - **Permissioned Games**: Should this still be supported?
-- **Netchef…**
+- **Docker-free callers**: the prepare/prestate/continue split lets an orchestrator without Docker run `prepare`, declare a prestate override in the intent, and run `continue`. Integration specifics for such callers are tracked separately.
 
 ---
 

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -71,7 +71,7 @@ The proposed flow:
 5. Build the genesis block from the allocs, chain config, and genesis timestamp.
 6. Compute the L2 genesis output root from the genesis block.
 7. Generate `depsets.json`. For non-interop chains this contains only the chain itself.
-8. Commit the prestate: the prestate is built through the monorepo's `reproducible-prestate` or `reproducible-prestate-kona` recipes used today. The `prestate` command commits the hash back into the pipeline.
+8. Commit the prestate: the prestate is built through the monorepo's `reproducible-prestate-kona` recipe used today. The `prestate` command commits the hash back into the pipeline.
 9. Submit `OPCM.deploy()` carrying the real `startingAnchorRoot` and `absolutePrestate`.
 10. Chain starts. The permissionless dispute game is valid from block 0.
 
@@ -297,7 +297,7 @@ A caller runs `prepare`, builds the prestate in the monorepo from the emitted ar
 ```mermaid
 flowchart TD
     A["prepare<br/>Steps 1–7 (off-chain)"] --> ART["genesis.json + rollup.json + depsets.json"]
-    ART -.-> BUILD["prestate built externally<br/>(reproducible-prestate recipes)"]
+    ART -.-> BUILD["prestate built externally<br/>(reproducible-prestate-kona recipe)"]
     BUILD --> B["prestate command<br/>hash via flag or intent override"]
     OV["prestate override<br/>declared in intent"] -.-> B
     B -->|"writes"| F["state: prestate"]

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -2,8 +2,8 @@
 
 |                    |                                    |
 | ------------------ | ---------------------------------- |
-| Author             | _Author Name_                      |
-| Created at         | _YYYY-MM-DD_                       |
+| Author             | Joxess, 0xOneTony, 0xiamflux       |
+| Created at         | _2026-05-26_                       |
 | Initial Reviewers  | _Reviewer Name 1, Reviewer Name 2_ |
 | Need Approval From | _Reviewer Name_                    |
 | Status             | _Draft_                            |

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -266,7 +266,7 @@ The resolved prestate hash is written to the state, and `op-deployer` reads `abs
 
 Three call-site changes are required:
 
-1. The OP Chain deployment script changes in three places. The require guard that restricts game types to `PERMISSIONED_CANNON` at initial deployment is removed. `CANNON` and `CANNON_KONA` are enabled with their respective prestate hashes read from the state. The hardcoded `0xdead` placeholder for the starting anchor root is replaced with the computed genesis output root.
+1. The OP Chain deployment script changes in three places. The require guard that restricts game types to `PERMISSIONED_CANNON` at initial deployment is replaced with a branch keyed on the intent: the default permissionless path enables `CANNON` and `CANNON_KONA` with their respective prestate hashes read from the state, and a permissioned-only deployment remains supported as a non-default option. The hardcoded `0xdead` placeholder for the starting anchor root is replaced with the computed genesis output root.
 2. The Go-side input struct for the OP Chain deployment gains a `StartingAnchorRoot` field and per-game-type prestate-hash fields.
 3. op-deployer's chain orchestration code wires those new fields through into the FullConfig passed to OPCM.
 

--- a/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
+++ b/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md
@@ -288,7 +288,7 @@ Runs after `DeployOPChain` completes. It confirms the deployed chain matches wha
 
 The prestate and the output root in the state are the hand-off point between the commands and the sole driver of continuation. `continue` reads them and proceeds only if they are set. If they are unset, the deployment halts.
 
-This is what lets a caller without Docker deploy: run `prepare`, have the prestate computed elsewhere, declare it as a prestate override in the intent, then run `continue`. A caller with Docker can run all three commands in sequence.
+This is what lets a caller without Docker deploy: run `prepare`, have the prestate computed elsewhere, declare it as an override in the intent so `op-deployer` resolves it as the canonical prestate in the state (no build, no Docker), then run `continue`. A caller with Docker can instead run `prestate` to build it in place, all three commands in sequence.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
## Purpose

Eliminate the ~7-day permissioned window every new OP Stack chain currently incurs before its permissionless dispute game can activate. The window is a deployment tooling artifact, and this document specifies the tooling redesign that removes it.

## Summary

New OP Stack chains today launch under a permissioned dispute game for roughly a week. The deployment pipeline can't seed the L1 dispute system with a real anchor at deploy time, because the L2 genesis depends on L1 contract addresses and the L1 dispute system needs the resulting output root, and today's tooling can't satisfy both at once. It ships placeholder values and defers permissionless proofs until a real dispute resolves a week later.

This design closes the gap by deriving everything off-chain before any transaction lands. `op-deployer` predicts the L1 contract addresses, builds the L2 genesis state and its output root, drives the prestate build, and finally submits `OPCM.deploy()` with the real values. The dispute system is seeded atomically with L1 contract deployment, and the permissionless game is valid from L2 block 0. No on-chain contract logic changes, the work lives entirely in tooling orchestration.

Closes #382 
Closes #383 